### PR TITLE
certgen: Add support for creating certs for external workloads

### DIFF
--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -43,6 +43,26 @@ const (
 	HubbleRelayClientCertSecretName       = "hubble-relay-client-certs"
 	HubbleRelayClientCertSecretNamespace  = "kube-system"
 
+	CiliumNamespace = "kube-system"
+
+	ExternalWorkloadCertsGenerate = true
+
+	ExternalWorkloadCACertCommonName       = "externalworkload-ca.cilium.io"
+	ExternalWorkloadCACertValidityDuration = 3 * 365 * 24 * time.Hour
+	ExternalWorkloadCACertSecretName       = "externalworkload-ca-cert"
+
+	ExternalWorkloadServerCertCommonName       = "clustermesh-apiserver.cilium.io"
+	ExternalWorkloadServerCertValidityDuration = 3 * 365 * 24 * time.Hour
+	ExternalWorkloadServerCertSecretName       = "externalworkload-server-certs"
+
+	ExternalWorkloadAdminCertCommonName       = "root"
+	ExternalWorkloadAdminCertValidityDuration = 3 * 365 * 24 * time.Hour
+	ExternalWorkloadAdminCertSecretName       = "externalworkload-admin-certs"
+
+	ExternalWorkloadClientCertCommonName       = "externalworkload"
+	ExternalWorkloadClientCertValidityDuration = 3 * 365 * 24 * time.Hour
+	ExternalWorkloadClientCertSecretName       = "externalworkload-client-certs"
+
 	K8sRequestTimeout = 60 * time.Second
 )
 
@@ -50,4 +70,6 @@ var (
 	HubbleServerCertUsage      = []string{"signing", "key encipherment", "server auth"}
 	HubbleRelayServerCertUsage = []string{"signing", "key encipherment", "server auth"}
 	HubbleRelayClientCertUsage = []string{"signing", "key encipherment", "server auth", "client auth"}
+
+	ExternalWorkloadCertUsage = []string{"signing", "key encipherment", "server auth", "client auth"}
 )

--- a/internal/option/config.go
+++ b/internal/option/config.go
@@ -54,6 +54,29 @@ const (
 	HubbleRelayClientCertSecretName       = "hubble-relay-client-cert-secret-name"
 	HubbleRelayClientCertSecretNamespace  = "hubble-relay-client-cert-secret-namespace"
 
+	CiliumNamespace = "cilium-namespace"
+
+	ExternalWorkloadCACertFile = "externalworkload-ca-cert-file"
+	ExternalWorkloadCAKeyFile  = "externalworkload-ca-key-file"
+
+	ExternalWorkloadCertsGenerate = "externalworkload-certs-generate"
+
+	ExternalWorkloadCACertCommonName       = "externalworkload-ca-cert-common-name"
+	ExternalWorkloadCACertValidityDuration = "externalworkload-ca-cert-validity-duration"
+	ExternalWorkloadCACertSecretName       = "externalworkload-ca-cert-secret-name"
+
+	ExternalWorkloadServerCertCommonName       = "externalworkload-server-cert-common-name"
+	ExternalWorkloadServerCertValidityDuration = "externalworkload-server-cert-validity-duration"
+	ExternalWorkloadServerCertSecretName       = "externalworkload-server-cert-secret-name"
+
+	ExternalWorkloadAdminCertCommonName       = "externalworkload-admin-cert-common-name"
+	ExternalWorkloadAdminCertValidityDuration = "externalworkload-admin-cert-validity-duration"
+	ExternalWorkloadAdminCertSecretName       = "externalworkload-admin-cert-secret-name"
+
+	ExternalWorkloadClientCertCommonName       = "externalworkload-client-cert-common-name"
+	ExternalWorkloadClientCertValidityDuration = "externalworkload-client-cert-validity-duration"
+	ExternalWorkloadClientCertSecretName       = "externalworkload-client-cert-secret-name"
+
 	K8sKubeConfigPath = "k8s-kubeconfig-path"
 	K8sRequestTimeout = "k8s-request-timeout"
 )
@@ -88,7 +111,7 @@ type CertGenConfig struct {
 
 	// HubbleRelayClientCertGenerate can be set to true to generate and store a Hubble Relay client cert
 	HubbleRelayClientCertGenerate bool
-	// HubbleRelayServerCertCommonName is the CN of the Hubble Relay client cert
+	// HubbleRelayClientCertCommonName is the CN of the Hubble Relay client cert
 	HubbleRelayClientCertCommonName string
 	// HubbleRelayClientCertValidityDuration of certificate
 	HubbleRelayClientCertValidityDuration time.Duration
@@ -118,6 +141,48 @@ type CertGenConfig struct {
 	HubbleServerCertSecretName string
 	// HubbleServerCertSecretNamespace where the Hubble server cert and key will be stored
 	HubbleServerCertSecretNamespace string
+
+	// CiliumNamespace where the secrets and configmaps will be stored
+	CiliumNamespace string
+
+	// ExternalWorkloadCACertFile is the path to the ExternalWorkload CA cert PEM (if ExternalWorkloadCertsGenerate is false)
+	ExternalWorkloadCACertFile string
+	// ExternalWorkloadCAKeyFile is the path to the ExternalWorkload CA key PEM (if ExternalWorkloadCertsGenerate is false)
+	ExternalWorkloadCAKeyFile string
+
+	// ExternalWorkloadCertsGenerate can be set to true to generate and store a new ExternalWorkload secrets and configmap
+	// New CA ConfigMap is created if created if existing one is not found. Delete the old ConfigMap to force regeneration.
+	// New CA is created if CA cert and key are not given.
+	// Server and client certs are created on each invocation.
+	ExternalWorkloadCertsGenerate bool
+
+	// ExternalWorkloadCACertCommonName is the CN of the ExternalWorkload CA
+	ExternalWorkloadCACertCommonName string
+	// ExternalWorkloadCACertValidityDuration of certificate
+	ExternalWorkloadCACertValidityDuration time.Duration
+	// ExternalWorkloadCACertSecretName where the ExternalWorkload CA cert will be stored
+	ExternalWorkloadCACertSecretName string
+
+	// ExternalWorkloadServerCertCommonName is the CN of the ExternalWorkload server cert
+	ExternalWorkloadServerCertCommonName string
+	// ExternalWorkloadServerCertValidityDuration of certificate
+	ExternalWorkloadServerCertValidityDuration time.Duration
+	// ExternalWorkloadServerCertSecretName where the ExternalWorkload server cert and key will be stored
+	ExternalWorkloadServerCertSecretName string
+
+	// ExternalWorkloadAdminCertCommonName is the CN of the ExternalWorkload admin cert
+	ExternalWorkloadAdminCertCommonName string
+	// ExternalWorkloadAdminCertValidityDuration of certificate
+	ExternalWorkloadAdminCertValidityDuration time.Duration
+	// ExternalWorkloadAdminCertSecretName where the ExternalWorkload admin cert and key will be stored
+	ExternalWorkloadAdminCertSecretName string
+
+	// ExternalWorkloadClientCertCommonName is the CN of the ExternalWorkload client cert
+	ExternalWorkloadClientCertCommonName string
+	// ExternalWorkloadClientCertValidityDuration of certificate
+	ExternalWorkloadClientCertValidityDuration time.Duration
+	// ExternalWorkloadClientCertSecretName where the ExternalWorkload client cert and key will be stored
+	ExternalWorkloadClientCertSecretName string
 }
 
 // PopulateFrom populates the config struct with the values provided by vp
@@ -152,4 +217,27 @@ func (c *CertGenConfig) PopulateFrom(vp *viper.Viper) {
 	c.HubbleServerCertValidityDuration = vp.GetDuration(HubbleServerCertValidityDuration)
 	c.HubbleServerCertSecretName = vp.GetString(HubbleServerCertSecretName)
 	c.HubbleServerCertSecretNamespace = vp.GetString(HubbleServerCertSecretNamespace)
+
+	c.CiliumNamespace = vp.GetString(CiliumNamespace)
+
+	c.ExternalWorkloadCACertFile = vp.GetString(ExternalWorkloadCACertFile)
+	c.ExternalWorkloadCAKeyFile = vp.GetString(ExternalWorkloadCAKeyFile)
+
+	c.ExternalWorkloadCertsGenerate = vp.GetBool(ExternalWorkloadCertsGenerate)
+
+	c.ExternalWorkloadCACertCommonName = vp.GetString(ExternalWorkloadCACertCommonName)
+	c.ExternalWorkloadCACertValidityDuration = vp.GetDuration(ExternalWorkloadCACertValidityDuration)
+	c.ExternalWorkloadCACertSecretName = vp.GetString(ExternalWorkloadCACertSecretName)
+
+	c.ExternalWorkloadServerCertCommonName = vp.GetString(ExternalWorkloadServerCertCommonName)
+	c.ExternalWorkloadServerCertValidityDuration = vp.GetDuration(ExternalWorkloadServerCertValidityDuration)
+	c.ExternalWorkloadServerCertSecretName = vp.GetString(ExternalWorkloadServerCertSecretName)
+
+	c.ExternalWorkloadAdminCertCommonName = vp.GetString(ExternalWorkloadAdminCertCommonName)
+	c.ExternalWorkloadAdminCertValidityDuration = vp.GetDuration(ExternalWorkloadAdminCertValidityDuration)
+	c.ExternalWorkloadAdminCertSecretName = vp.GetString(ExternalWorkloadAdminCertSecretName)
+
+	c.ExternalWorkloadClientCertCommonName = vp.GetString(ExternalWorkloadClientCertCommonName)
+	c.ExternalWorkloadClientCertValidityDuration = vp.GetDuration(ExternalWorkloadClientCertValidityDuration)
+	c.ExternalWorkloadClientCertSecretName = vp.GetString(ExternalWorkloadClientCertSecretName)
 }


### PR DESCRIPTION
Add support for creating certificates for external workloads. This is
mostly similar to how hubble certs are generated, but in anticipation
of the need to create new client certs on demand the CA key is also
stored in the configmap.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>