### PR TITLE
defaults: Do not generate anything by default.

### DIFF
--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -19,25 +19,25 @@ import "time"
 const (
 	Debug = false
 
-	HubbleCAGenerate           = true
+	HubbleCAGenerate           = false
 	HubbleCACommonName         = "hubble-ca.cilium.io"
 	HubbleCAValidityDuration   = 3 * 365 * 24 * time.Hour
 	HubbleCAConfigMapName      = "hubble-ca-cert"
 	HubbleCAConfigMapNamespace = "kube-system"
 
-	HubbleServerCertGenerate         = true
+	HubbleServerCertGenerate         = false
 	HubbleServerCertCommonName       = "*.default.hubble-grpc.cilium.io"
 	HubbleServerCertValidityDuration = 3 * 365 * 24 * time.Hour
 	HubbleServerCertSecretName       = "hubble-server-certs"
 	HubbleServerCertSecretNamespace  = "kube-system"
 
-	HubbleRelayServerCertGenerate         = true
+	HubbleRelayServerCertGenerate         = false
 	HubbleRelayServerCertCommonName       = "*.hubble-relay.cilium.io"
 	HubbleRelayServerCertValidityDuration = 3 * 365 * 24 * time.Hour
 	HubbleRelayServerCertSecretName       = "hubble-relay-server-certs"
 	HubbleRelayServerCertSecretNamespace  = "kube-system"
 
-	HubbleRelayClientCertGenerate         = true
+	HubbleRelayClientCertGenerate         = false
 	HubbleRelayClientCertCommonName       = "*.hubble-relay.cilium.io"
 	HubbleRelayClientCertValidityDuration = 3 * 365 * 24 * time.Hour
 	HubbleRelayClientCertSecretName       = "hubble-relay-client-certs"
@@ -45,7 +45,7 @@ const (
 
 	CiliumNamespace = "kube-system"
 
-	ExternalWorkloadCertsGenerate = true
+	ExternalWorkloadCertsGenerate = false
 
 	ExternalWorkloadCACertCommonName       = "externalworkload-ca.cilium.io"
 	ExternalWorkloadCACertValidityDuration = 3 * 365 * 24 * time.Hour


### PR DESCRIPTION
Now that we support key generation for multiple purposes it is better
to not assume anything about what is wanted. Current use seems to
explicitly use the affected "generate" flags anyway, so this should
not have any impact on how Cilium is using this, apart from not
generating external workload certs by default as now.

After this change, if nothing specific is requested, nothing is done:

$ ./cilium-certgen --k8s-kubeconfig-path ~/.kube/config
INFO[0000] cilium-certgen 0.1.1                          subsys=cilium-certgen
INFO[0000] Successfully generated all 0 requested certificates.  subsys=cilium-certgen

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>