### PR TITLE
certgen: Rename external workloads to clustermesh-apiserver

### DIFF
--- a/cmd/certgen.go
+++ b/cmd/certgen.go
@@ -99,26 +99,26 @@ func New() *cobra.Command {
 	// Extenal Workload certs
 	flags.String(option.CiliumNamespace, defaults.CiliumNamespace, "Namespace where the cert secrets and configmaps are stored in")
 
-	flags.String(option.ExternalWorkloadCACertFile, "", "Path to provided external workload CA certificate file (required if CA does not exist and is not to be generated)")
-	flags.String(option.ExternalWorkloadCAKeyFile, "", "Path to provided external workload CA key file (required if CA does not exist and is not to be generated)")
+	flags.String(option.ClustermeshApiserverCACertFile, "", "Path to provided clustermesh-apiserver CA certificate file (required if CA does not exist and is not to be generated)")
+	flags.String(option.ClustermeshApiserverCAKeyFile, "", "Path to provided clustermesh-apiserver CA key file (required if CA does not exist and is not to be generated)")
 
-	flags.Bool(option.ExternalWorkloadCertsGenerate, defaults.ExternalWorkloadCertsGenerate, "Generate and store external workload certificates")
+	flags.Bool(option.ClustermeshApiserverCertsGenerate, defaults.ClustermeshApiserverCertsGenerate, "Generate and store clustermesh-apiserver certificates")
 
-	flags.String(option.ExternalWorkloadCACertCommonName, defaults.ExternalWorkloadCACertCommonName, "External workload CA certificate common name")
-	flags.Duration(option.ExternalWorkloadCACertValidityDuration, defaults.ExternalWorkloadCACertValidityDuration, "External workload CA certificate validity duration")
-	flags.String(option.ExternalWorkloadCACertSecretName, defaults.ExternalWorkloadCACertSecretName, "Name of the K8s Secret where the external workload CA cert is stored in")
+	flags.String(option.ClustermeshApiserverCACertCommonName, defaults.ClustermeshApiserverCACertCommonName, "clustermesh-apiserver CA certificate common name")
+	flags.Duration(option.ClustermeshApiserverCACertValidityDuration, defaults.ClustermeshApiserverCACertValidityDuration, "clustermesh-apiserver CA certificate validity duration")
+	flags.String(option.ClustermeshApiserverCACertSecretName, defaults.ClustermeshApiserverCACertSecretName, "Name of the K8s Secret where the clustermesh-apiserver CA cert is stored in")
 
-	flags.String(option.ExternalWorkloadServerCertCommonName, defaults.ExternalWorkloadServerCertCommonName, "ExternalWorkload server certificate common name")
-	flags.Duration(option.ExternalWorkloadServerCertValidityDuration, defaults.ExternalWorkloadServerCertValidityDuration, "ExternalWorkload server certificate validity duration")
-	flags.String(option.ExternalWorkloadServerCertSecretName, defaults.ExternalWorkloadServerCertSecretName, "Name of the K8s Secret where the ExternalWorkload server cert and key are stored in")
+	flags.String(option.ClustermeshApiserverServerCertCommonName, defaults.ClustermeshApiserverServerCertCommonName, "clustermesh-apiserver server certificate common name")
+	flags.Duration(option.ClustermeshApiserverServerCertValidityDuration, defaults.ClustermeshApiserverServerCertValidityDuration, "clustermesh-apiserver server certificate validity duration")
+	flags.String(option.ClustermeshApiserverServerCertSecretName, defaults.ClustermeshApiserverServerCertSecretName, "Name of the K8s Secret where the clustermesh-apiserver server cert and key are stored in")
 
-	flags.String(option.ExternalWorkloadAdminCertCommonName, defaults.ExternalWorkloadAdminCertCommonName, "ExternalWorkload admin certificate common name")
-	flags.Duration(option.ExternalWorkloadAdminCertValidityDuration, defaults.ExternalWorkloadAdminCertValidityDuration, "ExternalWorkload admin certificate validity duration")
-	flags.String(option.ExternalWorkloadAdminCertSecretName, defaults.ExternalWorkloadAdminCertSecretName, "Name of the K8s Secret where the ExternalWorkload admin cert and key are stored in")
+	flags.String(option.ClustermeshApiserverAdminCertCommonName, defaults.ClustermeshApiserverAdminCertCommonName, "clustermesh-apiserver admin certificate common name")
+	flags.Duration(option.ClustermeshApiserverAdminCertValidityDuration, defaults.ClustermeshApiserverAdminCertValidityDuration, "clustermesh-apiserver admin certificate validity duration")
+	flags.String(option.ClustermeshApiserverAdminCertSecretName, defaults.ClustermeshApiserverAdminCertSecretName, "Name of the K8s Secret where the clustermesh-apiserver admin cert and key are stored in")
 
-	flags.String(option.ExternalWorkloadClientCertCommonName, defaults.ExternalWorkloadClientCertCommonName, "ExternalWorkload client certificate common name")
-	flags.Duration(option.ExternalWorkloadClientCertValidityDuration, defaults.ExternalWorkloadClientCertValidityDuration, "ExternalWorkload client certificate validity duration")
-	flags.String(option.ExternalWorkloadClientCertSecretName, defaults.ExternalWorkloadClientCertSecretName, "Name of the K8s Secret where the ExternalWorkload client cert and key are stored in")
+	flags.String(option.ClustermeshApiserverClientCertCommonName, defaults.ClustermeshApiserverClientCertCommonName, "clustermesh-apiserver client certificate common name")
+	flags.Duration(option.ClustermeshApiserverClientCertValidityDuration, defaults.ClustermeshApiserverClientCertValidityDuration, "clustermesh-apiserver client certificate validity duration")
+	flags.String(option.ClustermeshApiserverClientCertSecretName, defaults.ClustermeshApiserverClientCertSecretName, "Name of the K8s Secret where the clustermesh-apiserver client cert and key are stored in")
 
 	// Sets up viper to read in flags via CILIUM_CERTGEN_ env variables
 	vp.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
@@ -258,106 +258,106 @@ func generateCertificates() error {
 		count++
 	}
 
-	if option.Config.ExternalWorkloadCertsGenerate {
+	if option.Config.ClustermeshApiserverCertsGenerate {
 		haveCASecret := false
-		externalworkloadCA := generate.NewCA(option.Config.ExternalWorkloadCACertSecretName, option.Config.CiliumNamespace)
+		clustermeshApiserverCA := generate.NewCA(option.Config.ClustermeshApiserverCACertSecretName, option.Config.CiliumNamespace)
 
 		// Load CA from file?
-		if option.Config.ExternalWorkloadCACertFile != "" && option.Config.ExternalWorkloadCAKeyFile != "" {
-			log.Info("Loading ExternalWorkload CA from file")
-			err = externalworkloadCA.LoadFromFile(option.Config.ExternalWorkloadCACertFile, option.Config.ExternalWorkloadCAKeyFile)
+		if option.Config.ClustermeshApiserverCACertFile != "" && option.Config.ClustermeshApiserverCAKeyFile != "" {
+			log.Info("Loading ClustermeshApiserver CA from file")
+			err = clustermeshApiserverCA.LoadFromFile(option.Config.ClustermeshApiserverCACertFile, option.Config.ClustermeshApiserverCAKeyFile)
 			if err != nil {
-				return fmt.Errorf("failed to load ExternalWorkload CA: %w", err)
+				return fmt.Errorf("failed to load ClustermeshApiserver CA: %w", err)
 			}
 		} else {
 			// Does the secret already exist?
 			ctx, cancel := context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
 			defer cancel()
-			err = externalworkloadCA.LoadFromSecret(ctx, k8sClient)
+			err = clustermeshApiserverCA.LoadFromSecret(ctx, k8sClient)
 			if err != nil {
 				if k8sErrors.IsNotFound(err) {
-					log.Info("ExternalWorkload CA secret does not exist, generating new CA")
-					err = externalworkloadCA.Generate(option.Config.ExternalWorkloadCACertCommonName, option.Config.ExternalWorkloadCACertValidityDuration)
+					log.Info("ClustermeshApiserver CA secret does not exist, generating new CA")
+					err = clustermeshApiserverCA.Generate(option.Config.ClustermeshApiserverCACertCommonName, option.Config.ClustermeshApiserverCACertValidityDuration)
 					if err != nil {
-						return fmt.Errorf("failed to generate ExternalWorkload CA: %w", err)
+						return fmt.Errorf("failed to generate ClustermeshApiserver CA: %w", err)
 					}
 				} else {
 					// Permission error or something like that
-					return fmt.Errorf("failed to load ExternalWorkload CA secret: %w", err)
+					return fmt.Errorf("failed to load ClustermeshApiserver CA secret: %w", err)
 				}
 			} else {
-				log.Info("Loaded ExternalWorkload CA Secret")
+				log.Info("Loaded ClustermeshApiserver CA Secret")
 				haveCASecret = true
 			}
 		}
 
-		log.Info("Generating server certificate for ExternalWorkload")
-		externalworkloadServerCert := generate.NewCert(
-			option.Config.ExternalWorkloadServerCertCommonName,
-			option.Config.ExternalWorkloadServerCertValidityDuration,
-			defaults.ExternalWorkloadCertUsage,
-			option.Config.ExternalWorkloadServerCertSecretName,
+		log.Info("Generating server certificate for ClustermeshApiserver")
+		clustermeshApiserverServerCert := generate.NewCert(
+			option.Config.ClustermeshApiserverServerCertCommonName,
+			option.Config.ClustermeshApiserverServerCertValidityDuration,
+			defaults.ClustermeshApiserverCertUsage,
+			option.Config.ClustermeshApiserverServerCertSecretName,
 			option.Config.CiliumNamespace,
-		).WithHosts([]string{option.Config.ExternalWorkloadServerCertCommonName, "127.0.0.1"})
-		err = externalworkloadServerCert.Generate(externalworkloadCA.CACert, externalworkloadCA.CAKey)
+		).WithHosts([]string{option.Config.ClustermeshApiserverServerCertCommonName, "127.0.0.1"})
+		err = clustermeshApiserverServerCert.Generate(clustermeshApiserverCA.CACert, clustermeshApiserverCA.CAKey)
 		if err != nil {
-			return fmt.Errorf("failed to generate ExternalWorkload server cert: %w", err)
+			return fmt.Errorf("failed to generate ClustermeshApiserver server cert: %w", err)
 		}
 
-		log.Info("Generating admin certificate for ExternalWorkload")
-		externalworkloadAdminCert := generate.NewCert(
-			option.Config.ExternalWorkloadAdminCertCommonName,
-			option.Config.ExternalWorkloadAdminCertValidityDuration,
-			defaults.ExternalWorkloadCertUsage,
-			option.Config.ExternalWorkloadAdminCertSecretName,
+		log.Info("Generating admin certificate for ClustermeshApiserver")
+		clustermeshApiserverAdminCert := generate.NewCert(
+			option.Config.ClustermeshApiserverAdminCertCommonName,
+			option.Config.ClustermeshApiserverAdminCertValidityDuration,
+			defaults.ClustermeshApiserverCertUsage,
+			option.Config.ClustermeshApiserverAdminCertSecretName,
 			option.Config.CiliumNamespace,
 		).WithHosts([]string{"localhost"})
-		err = externalworkloadAdminCert.Generate(externalworkloadCA.CACert, externalworkloadCA.CAKey)
+		err = clustermeshApiserverAdminCert.Generate(clustermeshApiserverCA.CACert, clustermeshApiserverCA.CAKey)
 		if err != nil {
-			return fmt.Errorf("failed to generate ExternalWorkload admin cert: %w", err)
+			return fmt.Errorf("failed to generate ClustermeshApiserver admin cert: %w", err)
 		}
 
-		log.Info("Generating client certificate for ExternalWorkload")
-		externalworkloadClientCert := generate.NewCert(
-			option.Config.ExternalWorkloadClientCertCommonName,
-			option.Config.ExternalWorkloadClientCertValidityDuration,
-			defaults.ExternalWorkloadCertUsage,
-			option.Config.ExternalWorkloadClientCertSecretName,
+		log.Info("Generating client certificate for ClustermeshApiserver")
+		clustermeshApiserverClientCert := generate.NewCert(
+			option.Config.ClustermeshApiserverClientCertCommonName,
+			option.Config.ClustermeshApiserverClientCertValidityDuration,
+			defaults.ClustermeshApiserverCertUsage,
+			option.Config.ClustermeshApiserverClientCertSecretName,
 			option.Config.CiliumNamespace,
 		)
-		err = externalworkloadClientCert.Generate(externalworkloadCA.CACert, externalworkloadCA.CAKey)
+		err = clustermeshApiserverClientCert.Generate(clustermeshApiserverCA.CACert, clustermeshApiserverCA.CAKey)
 		if err != nil {
-			return fmt.Errorf("failed to generate ExternalWorkload client cert: %w", err)
+			return fmt.Errorf("failed to generate ClustermeshApiserver client cert: %w", err)
 		}
 
 		// Store the generated certs
 		if !haveCASecret {
 			ctx, cancel := context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
 			defer cancel()
-			if err := externalworkloadCA.StoreAsSecret(ctx, k8sClient); err != nil {
-				return fmt.Errorf("failed to create secret for ExternalWorkload CA: %w", err)
+			if err := clustermeshApiserverCA.StoreAsSecret(ctx, k8sClient); err != nil {
+				return fmt.Errorf("failed to create secret for ClustermeshApiserver CA: %w", err)
 			}
 			count++
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
 		defer cancel()
-		if err := externalworkloadServerCert.StoreAsSecretWithCACert(ctx, k8sClient, externalworkloadCA); err != nil {
-			return fmt.Errorf("failed to create secret for ExternalWorkload server cert: %w", err)
+		if err := clustermeshApiserverServerCert.StoreAsSecretWithCACert(ctx, k8sClient, clustermeshApiserverCA); err != nil {
+			return fmt.Errorf("failed to create secret for ClustermeshApiserver server cert: %w", err)
 		}
 		count++
 
 		ctx, cancel = context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
 		defer cancel()
-		if err := externalworkloadAdminCert.StoreAsSecretWithCACert(ctx, k8sClient, externalworkloadCA); err != nil {
-			return fmt.Errorf("failed to create secret for ExternalWorkload admin cert: %w", err)
+		if err := clustermeshApiserverAdminCert.StoreAsSecretWithCACert(ctx, k8sClient, clustermeshApiserverCA); err != nil {
+			return fmt.Errorf("failed to create secret for ClustermeshApiserver admin cert: %w", err)
 		}
 		count++
 
 		ctx, cancel = context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
 		defer cancel()
-		if err := externalworkloadClientCert.StoreAsSecretWithCACert(ctx, k8sClient, externalworkloadCA); err != nil {
-			return fmt.Errorf("failed to create secret for ExternalWorkload client cert: %w", err)
+		if err := clustermeshApiserverClientCert.StoreAsSecretWithCACert(ctx, k8sClient, clustermeshApiserverCA); err != nil {
+			return fmt.Errorf("failed to create secret for ClustermeshApiserver client cert: %w", err)
 		}
 		count++
 	}

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -45,23 +45,23 @@ const (
 
 	CiliumNamespace = "kube-system"
 
-	ExternalWorkloadCertsGenerate = false
+	ClustermeshApiserverCertsGenerate = false
 
-	ExternalWorkloadCACertCommonName       = "externalworkload-ca.cilium.io"
-	ExternalWorkloadCACertValidityDuration = 3 * 365 * 24 * time.Hour
-	ExternalWorkloadCACertSecretName       = "externalworkload-ca-cert"
+	ClustermeshApiserverCACertCommonName       = "clustermesh-apiserver-ca.cilium.io"
+	ClustermeshApiserverCACertValidityDuration = 3 * 365 * 24 * time.Hour
+	ClustermeshApiserverCACertSecretName       = "clustermesh-apiserver-ca-cert"
 
-	ExternalWorkloadServerCertCommonName       = "clustermesh-apiserver.cilium.io"
-	ExternalWorkloadServerCertValidityDuration = 3 * 365 * 24 * time.Hour
-	ExternalWorkloadServerCertSecretName       = "externalworkload-server-certs"
+	ClustermeshApiserverServerCertCommonName       = "clustermesh-apiserver.cilium.io"
+	ClustermeshApiserverServerCertValidityDuration = 3 * 365 * 24 * time.Hour
+	ClustermeshApiserverServerCertSecretName       = "clustermesh-apiserver-server-cert"
 
-	ExternalWorkloadAdminCertCommonName       = "root"
-	ExternalWorkloadAdminCertValidityDuration = 3 * 365 * 24 * time.Hour
-	ExternalWorkloadAdminCertSecretName       = "externalworkload-admin-certs"
+	ClustermeshApiserverAdminCertCommonName       = "root"
+	ClustermeshApiserverAdminCertValidityDuration = 3 * 365 * 24 * time.Hour
+	ClustermeshApiserverAdminCertSecretName       = "clustermesh-apiserver-admin-cert"
 
-	ExternalWorkloadClientCertCommonName       = "externalworkload"
-	ExternalWorkloadClientCertValidityDuration = 3 * 365 * 24 * time.Hour
-	ExternalWorkloadClientCertSecretName       = "externalworkload-client-certs"
+	ClustermeshApiserverClientCertCommonName       = "externalworkload"
+	ClustermeshApiserverClientCertValidityDuration = 3 * 365 * 24 * time.Hour
+	ClustermeshApiserverClientCertSecretName       = "clustermesh-apiserver-client-cert"
 
 	K8sRequestTimeout = 60 * time.Second
 )
@@ -71,5 +71,5 @@ var (
 	HubbleRelayServerCertUsage = []string{"signing", "key encipherment", "server auth"}
 	HubbleRelayClientCertUsage = []string{"signing", "key encipherment", "server auth", "client auth"}
 
-	ExternalWorkloadCertUsage = []string{"signing", "key encipherment", "server auth", "client auth"}
+	ClustermeshApiserverCertUsage = []string{"signing", "key encipherment", "server auth", "client auth"}
 )

--- a/internal/option/config.go
+++ b/internal/option/config.go
@@ -56,26 +56,26 @@ const (
 
 	CiliumNamespace = "cilium-namespace"
 
-	ExternalWorkloadCACertFile = "externalworkload-ca-cert-file"
-	ExternalWorkloadCAKeyFile  = "externalworkload-ca-key-file"
+	ClustermeshApiserverCACertFile = "clustermesh-apiserver-ca-cert-file"
+	ClustermeshApiserverCAKeyFile  = "clustermesh-apiserver-ca-key-file"
 
-	ExternalWorkloadCertsGenerate = "externalworkload-certs-generate"
+	ClustermeshApiserverCertsGenerate = "clustermesh-apiserver-certs-generate"
 
-	ExternalWorkloadCACertCommonName       = "externalworkload-ca-cert-common-name"
-	ExternalWorkloadCACertValidityDuration = "externalworkload-ca-cert-validity-duration"
-	ExternalWorkloadCACertSecretName       = "externalworkload-ca-cert-secret-name"
+	ClustermeshApiserverCACertCommonName       = "clustermesh-apiserver-ca-cert-common-name"
+	ClustermeshApiserverCACertValidityDuration = "clustermesh-apiserver-ca-cert-validity-duration"
+	ClustermeshApiserverCACertSecretName       = "clustermesh-apiserver-ca-cert-secret-name"
 
-	ExternalWorkloadServerCertCommonName       = "externalworkload-server-cert-common-name"
-	ExternalWorkloadServerCertValidityDuration = "externalworkload-server-cert-validity-duration"
-	ExternalWorkloadServerCertSecretName       = "externalworkload-server-cert-secret-name"
+	ClustermeshApiserverServerCertCommonName       = "clustermesh-apiserver-server-cert-common-name"
+	ClustermeshApiserverServerCertValidityDuration = "clustermesh-apiserver-server-cert-validity-duration"
+	ClustermeshApiserverServerCertSecretName       = "clustermesh-apiserver-server-cert-secret-name"
 
-	ExternalWorkloadAdminCertCommonName       = "externalworkload-admin-cert-common-name"
-	ExternalWorkloadAdminCertValidityDuration = "externalworkload-admin-cert-validity-duration"
-	ExternalWorkloadAdminCertSecretName       = "externalworkload-admin-cert-secret-name"
+	ClustermeshApiserverAdminCertCommonName       = "clustermesh-apiserver-admin-cert-common-name"
+	ClustermeshApiserverAdminCertValidityDuration = "clustermesh-apiserver-admin-cert-validity-duration"
+	ClustermeshApiserverAdminCertSecretName       = "clustermesh-apiserver-admin-cert-secret-name"
 
-	ExternalWorkloadClientCertCommonName       = "externalworkload-client-cert-common-name"
-	ExternalWorkloadClientCertValidityDuration = "externalworkload-client-cert-validity-duration"
-	ExternalWorkloadClientCertSecretName       = "externalworkload-client-cert-secret-name"
+	ClustermeshApiserverClientCertCommonName       = "clustermesh-apiserver-client-cert-common-name"
+	ClustermeshApiserverClientCertValidityDuration = "clustermesh-apiserver-client-cert-validity-duration"
+	ClustermeshApiserverClientCertSecretName       = "clustermesh-apiserver-client-cert-secret-name"
 
 	K8sKubeConfigPath = "k8s-kubeconfig-path"
 	K8sRequestTimeout = "k8s-request-timeout"
@@ -145,44 +145,44 @@ type CertGenConfig struct {
 	// CiliumNamespace where the secrets and configmaps will be stored
 	CiliumNamespace string
 
-	// ExternalWorkloadCACertFile is the path to the ExternalWorkload CA cert PEM (if ExternalWorkloadCertsGenerate is false)
-	ExternalWorkloadCACertFile string
-	// ExternalWorkloadCAKeyFile is the path to the ExternalWorkload CA key PEM (if ExternalWorkloadCertsGenerate is false)
-	ExternalWorkloadCAKeyFile string
+	// ClustermeshApiserverCACertFile is the path to the ClustermeshApiserver CA cert PEM (if ClustermeshApiserverCertsGenerate is false)
+	ClustermeshApiserverCACertFile string
+	// ClustermeshApiserverCAKeyFile is the path to the ClustermeshApiserver CA key PEM (if ClustermeshApiserverCertsGenerate is false)
+	ClustermeshApiserverCAKeyFile string
 
-	// ExternalWorkloadCertsGenerate can be set to true to generate and store a new ExternalWorkload secrets and configmap
+	// ClustermeshApiserverCertsGenerate can be set to true to generate and store a new ClustermeshApiserver secrets and configmap
 	// New CA ConfigMap is created if created if existing one is not found. Delete the old ConfigMap to force regeneration.
 	// New CA is created if CA cert and key are not given.
 	// Server and client certs are created on each invocation.
-	ExternalWorkloadCertsGenerate bool
+	ClustermeshApiserverCertsGenerate bool
 
-	// ExternalWorkloadCACertCommonName is the CN of the ExternalWorkload CA
-	ExternalWorkloadCACertCommonName string
-	// ExternalWorkloadCACertValidityDuration of certificate
-	ExternalWorkloadCACertValidityDuration time.Duration
-	// ExternalWorkloadCACertSecretName where the ExternalWorkload CA cert will be stored
-	ExternalWorkloadCACertSecretName string
+	// ClustermeshApiserverCACertCommonName is the CN of the ClustermeshApiserver CA
+	ClustermeshApiserverCACertCommonName string
+	// ClustermeshApiserverCACertValidityDuration of certificate
+	ClustermeshApiserverCACertValidityDuration time.Duration
+	// ClustermeshApiserverCACertSecretName where the ClustermeshApiserver CA cert will be stored
+	ClustermeshApiserverCACertSecretName string
 
-	// ExternalWorkloadServerCertCommonName is the CN of the ExternalWorkload server cert
-	ExternalWorkloadServerCertCommonName string
-	// ExternalWorkloadServerCertValidityDuration of certificate
-	ExternalWorkloadServerCertValidityDuration time.Duration
-	// ExternalWorkloadServerCertSecretName where the ExternalWorkload server cert and key will be stored
-	ExternalWorkloadServerCertSecretName string
+	// ClustermeshApiserverServerCertCommonName is the CN of the ClustermeshApiserver server cert
+	ClustermeshApiserverServerCertCommonName string
+	// ClustermeshApiserverServerCertValidityDuration of certificate
+	ClustermeshApiserverServerCertValidityDuration time.Duration
+	// ClustermeshApiserverServerCertSecretName where the ClustermeshApiserver server cert and key will be stored
+	ClustermeshApiserverServerCertSecretName string
 
-	// ExternalWorkloadAdminCertCommonName is the CN of the ExternalWorkload admin cert
-	ExternalWorkloadAdminCertCommonName string
-	// ExternalWorkloadAdminCertValidityDuration of certificate
-	ExternalWorkloadAdminCertValidityDuration time.Duration
-	// ExternalWorkloadAdminCertSecretName where the ExternalWorkload admin cert and key will be stored
-	ExternalWorkloadAdminCertSecretName string
+	// ClustermeshApiserverAdminCertCommonName is the CN of the ClustermeshApiserver admin cert
+	ClustermeshApiserverAdminCertCommonName string
+	// ClustermeshApiserverAdminCertValidityDuration of certificate
+	ClustermeshApiserverAdminCertValidityDuration time.Duration
+	// ClustermeshApiserverAdminCertSecretName where the ClustermeshApiserver admin cert and key will be stored
+	ClustermeshApiserverAdminCertSecretName string
 
-	// ExternalWorkloadClientCertCommonName is the CN of the ExternalWorkload client cert
-	ExternalWorkloadClientCertCommonName string
-	// ExternalWorkloadClientCertValidityDuration of certificate
-	ExternalWorkloadClientCertValidityDuration time.Duration
-	// ExternalWorkloadClientCertSecretName where the ExternalWorkload client cert and key will be stored
-	ExternalWorkloadClientCertSecretName string
+	// ClustermeshApiserverClientCertCommonName is the CN of the ClustermeshApiserver client cert
+	ClustermeshApiserverClientCertCommonName string
+	// ClustermeshApiserverClientCertValidityDuration of certificate
+	ClustermeshApiserverClientCertValidityDuration time.Duration
+	// ClustermeshApiserverClientCertSecretName where the ClustermeshApiserver client cert and key will be stored
+	ClustermeshApiserverClientCertSecretName string
 }
 
 // PopulateFrom populates the config struct with the values provided by vp
@@ -220,24 +220,24 @@ func (c *CertGenConfig) PopulateFrom(vp *viper.Viper) {
 
 	c.CiliumNamespace = vp.GetString(CiliumNamespace)
 
-	c.ExternalWorkloadCACertFile = vp.GetString(ExternalWorkloadCACertFile)
-	c.ExternalWorkloadCAKeyFile = vp.GetString(ExternalWorkloadCAKeyFile)
+	c.ClustermeshApiserverCACertFile = vp.GetString(ClustermeshApiserverCACertFile)
+	c.ClustermeshApiserverCAKeyFile = vp.GetString(ClustermeshApiserverCAKeyFile)
 
-	c.ExternalWorkloadCertsGenerate = vp.GetBool(ExternalWorkloadCertsGenerate)
+	c.ClustermeshApiserverCertsGenerate = vp.GetBool(ClustermeshApiserverCertsGenerate)
 
-	c.ExternalWorkloadCACertCommonName = vp.GetString(ExternalWorkloadCACertCommonName)
-	c.ExternalWorkloadCACertValidityDuration = vp.GetDuration(ExternalWorkloadCACertValidityDuration)
-	c.ExternalWorkloadCACertSecretName = vp.GetString(ExternalWorkloadCACertSecretName)
+	c.ClustermeshApiserverCACertCommonName = vp.GetString(ClustermeshApiserverCACertCommonName)
+	c.ClustermeshApiserverCACertValidityDuration = vp.GetDuration(ClustermeshApiserverCACertValidityDuration)
+	c.ClustermeshApiserverCACertSecretName = vp.GetString(ClustermeshApiserverCACertSecretName)
 
-	c.ExternalWorkloadServerCertCommonName = vp.GetString(ExternalWorkloadServerCertCommonName)
-	c.ExternalWorkloadServerCertValidityDuration = vp.GetDuration(ExternalWorkloadServerCertValidityDuration)
-	c.ExternalWorkloadServerCertSecretName = vp.GetString(ExternalWorkloadServerCertSecretName)
+	c.ClustermeshApiserverServerCertCommonName = vp.GetString(ClustermeshApiserverServerCertCommonName)
+	c.ClustermeshApiserverServerCertValidityDuration = vp.GetDuration(ClustermeshApiserverServerCertValidityDuration)
+	c.ClustermeshApiserverServerCertSecretName = vp.GetString(ClustermeshApiserverServerCertSecretName)
 
-	c.ExternalWorkloadAdminCertCommonName = vp.GetString(ExternalWorkloadAdminCertCommonName)
-	c.ExternalWorkloadAdminCertValidityDuration = vp.GetDuration(ExternalWorkloadAdminCertValidityDuration)
-	c.ExternalWorkloadAdminCertSecretName = vp.GetString(ExternalWorkloadAdminCertSecretName)
+	c.ClustermeshApiserverAdminCertCommonName = vp.GetString(ClustermeshApiserverAdminCertCommonName)
+	c.ClustermeshApiserverAdminCertValidityDuration = vp.GetDuration(ClustermeshApiserverAdminCertValidityDuration)
+	c.ClustermeshApiserverAdminCertSecretName = vp.GetString(ClustermeshApiserverAdminCertSecretName)
 
-	c.ExternalWorkloadClientCertCommonName = vp.GetString(ExternalWorkloadClientCertCommonName)
-	c.ExternalWorkloadClientCertValidityDuration = vp.GetDuration(ExternalWorkloadClientCertValidityDuration)
-	c.ExternalWorkloadClientCertSecretName = vp.GetString(ExternalWorkloadClientCertSecretName)
+	c.ClustermeshApiserverClientCertCommonName = vp.GetString(ClustermeshApiserverClientCertCommonName)
+	c.ClustermeshApiserverClientCertValidityDuration = vp.GetDuration(ClustermeshApiserverClientCertValidityDuration)
+	c.ClustermeshApiserverClientCertSecretName = vp.GetString(ClustermeshApiserverClientCertSecretName)
 }


### PR DESCRIPTION
Keys generated for extarnal workloads can also be used for clustermesh
when deployed through clustermesh-apiserver. Rename to make it clear
that these are clustermesh-apiserver certs.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>