### PR TITLE
Add support for clustermesh remote cluster cert

### DIFF
--- a/cmd/certgen.go
+++ b/cmd/certgen.go
@@ -161,7 +161,6 @@ func generateCertificates() error {
 	if err != nil {
 		return fmt.Errorf("failed initialize kubernetes client: %w", err)
 	}
-	count := 0
 
 	hubbleCA := generate.NewCA(option.Config.HubbleCAConfigMapName, option.Config.HubbleCAConfigMapNamespace)
 	if option.Config.HubbleCAGenerate {
@@ -224,42 +223,6 @@ func generateCertificates() error {
 		if err != nil {
 			return fmt.Errorf("failed to generate Hubble Relay server cert: %w", err)
 		}
-	}
-
-	if option.Config.HubbleCAGenerate {
-		ctx, cancel := context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
-		defer cancel()
-		if err := hubbleCA.StoreAsConfigMap(ctx, k8sClient); err != nil {
-			return fmt.Errorf("failed to create configmap for Hubble CA: %w", err)
-		}
-		count++
-	}
-
-	if option.Config.HubbleServerCertGenerate {
-		ctx, cancel := context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
-		defer cancel()
-		if err := hubbleServerCert.StoreAsSecret(ctx, k8sClient); err != nil {
-			return fmt.Errorf("failed to create secret for Hubble server cert: %w", err)
-		}
-		count++
-	}
-
-	if option.Config.HubbleRelayClientCertGenerate {
-		ctx, cancel := context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
-		defer cancel()
-		if err := hubbleRelayClientCert.StoreAsSecret(ctx, k8sClient); err != nil {
-			return fmt.Errorf("failed to create secret for Hubble Relay client cert: %w", err)
-		}
-		count++
-	}
-
-	if option.Config.HubbleRelayServerCertGenerate {
-		ctx, cancel := context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
-		defer cancel()
-		if err := hubbleRelayServerCert.StoreAsSecret(ctx, k8sClient); err != nil {
-			return fmt.Errorf("failed to create secret for Hubble Relay server cert: %w", err)
-		}
-		count++
 	}
 
 	if option.Config.ClustermeshApiserverCertsGenerate {
@@ -346,8 +309,48 @@ func generateCertificates() error {
 		if err != nil {
 			return fmt.Errorf("failed to generate ClustermeshApiserver remote cert: %w", err)
 		}
+	}
 
-		// Store the generated certs
+	// Store after all the requested certs have been succesfully generated
+	count := 0
+
+	if option.Config.HubbleCAGenerate {
+		ctx, cancel := context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
+		defer cancel()
+		if err := hubbleCA.StoreAsConfigMap(ctx, k8sClient); err != nil {
+			return fmt.Errorf("failed to create configmap for Hubble CA: %w", err)
+		}
+		count++
+	}
+
+	if option.Config.HubbleServerCertGenerate {
+		ctx, cancel := context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
+		defer cancel()
+		if err := hubbleServerCert.StoreAsSecret(ctx, k8sClient); err != nil {
+			return fmt.Errorf("failed to create secret for Hubble server cert: %w", err)
+		}
+		count++
+	}
+
+	if option.Config.HubbleRelayClientCertGenerate {
+		ctx, cancel := context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
+		defer cancel()
+		if err := hubbleRelayClientCert.StoreAsSecret(ctx, k8sClient); err != nil {
+			return fmt.Errorf("failed to create secret for Hubble Relay client cert: %w", err)
+		}
+		count++
+	}
+
+	if option.Config.HubbleRelayServerCertGenerate {
+		ctx, cancel := context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
+		defer cancel()
+		if err := hubbleRelayServerCert.StoreAsSecret(ctx, k8sClient); err != nil {
+			return fmt.Errorf("failed to create secret for Hubble Relay server cert: %w", err)
+		}
+		count++
+	}
+
+	if option.Config.ClustermeshApiserverCertsGenerate {
 		if !haveCASecret {
 			ctx, cancel := context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
 			defer cancel()

--- a/cmd/certgen.go
+++ b/cmd/certgen.go
@@ -342,21 +342,21 @@ func generateCertificates() error {
 
 		ctx, cancel := context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
 		defer cancel()
-		if err := clustermeshApiserverServerCert.StoreAsSecretWithCACert(ctx, k8sClient, clustermeshApiserverCA); err != nil {
+		if err := clustermeshApiserverServerCert.StoreAsSecret(ctx, k8sClient); err != nil {
 			return fmt.Errorf("failed to create secret for ClustermeshApiserver server cert: %w", err)
 		}
 		count++
 
 		ctx, cancel = context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
 		defer cancel()
-		if err := clustermeshApiserverAdminCert.StoreAsSecretWithCACert(ctx, k8sClient, clustermeshApiserverCA); err != nil {
+		if err := clustermeshApiserverAdminCert.StoreAsSecret(ctx, k8sClient); err != nil {
 			return fmt.Errorf("failed to create secret for ClustermeshApiserver admin cert: %w", err)
 		}
 		count++
 
 		ctx, cancel = context.WithTimeout(context.Background(), option.Config.K8sRequestTimeout)
 		defer cancel()
-		if err := clustermeshApiserverClientCert.StoreAsSecretWithCACert(ctx, k8sClient, clustermeshApiserverCA); err != nil {
+		if err := clustermeshApiserverClientCert.StoreAsSecret(ctx, k8sClient); err != nil {
 			return fmt.Errorf("failed to create secret for ClustermeshApiserver client cert: %w", err)
 		}
 		count++

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -63,6 +63,10 @@ const (
 	ClustermeshApiserverClientCertValidityDuration = 3 * 365 * 24 * time.Hour
 	ClustermeshApiserverClientCertSecretName       = "clustermesh-apiserver-client-cert"
 
+	ClustermeshApiserverRemoteCertCommonName       = "remote"
+	ClustermeshApiserverRemoteCertValidityDuration = 3 * 365 * 24 * time.Hour
+	ClustermeshApiserverRemoteCertSecretName       = "clustermesh-apiserver-remote-cert"
+
 	K8sRequestTimeout = 60 * time.Second
 )
 

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -45,24 +45,27 @@ const (
 
 	CiliumNamespace = "kube-system"
 
-	ClustermeshApiserverCertsGenerate = false
-
+	ClustermeshApiserverCACertGenerate         = false
 	ClustermeshApiserverCACertCommonName       = "clustermesh-apiserver-ca.cilium.io"
 	ClustermeshApiserverCACertValidityDuration = 3 * 365 * 24 * time.Hour
 	ClustermeshApiserverCACertSecretName       = "clustermesh-apiserver-ca-cert"
 
+	ClustermeshApiserverServerCertGenerate         = false
 	ClustermeshApiserverServerCertCommonName       = "clustermesh-apiserver.cilium.io"
 	ClustermeshApiserverServerCertValidityDuration = 3 * 365 * 24 * time.Hour
 	ClustermeshApiserverServerCertSecretName       = "clustermesh-apiserver-server-cert"
 
+	ClustermeshApiserverAdminCertGenerate         = false
 	ClustermeshApiserverAdminCertCommonName       = "root"
 	ClustermeshApiserverAdminCertValidityDuration = 3 * 365 * 24 * time.Hour
 	ClustermeshApiserverAdminCertSecretName       = "clustermesh-apiserver-admin-cert"
 
+	ClustermeshApiserverClientCertGenerate         = false
 	ClustermeshApiserverClientCertCommonName       = "externalworkload"
 	ClustermeshApiserverClientCertValidityDuration = 3 * 365 * 24 * time.Hour
 	ClustermeshApiserverClientCertSecretName       = "clustermesh-apiserver-client-cert"
 
+	ClustermeshApiserverRemoteCertGenerate         = false
 	ClustermeshApiserverRemoteCertCommonName       = "remote"
 	ClustermeshApiserverRemoteCertValidityDuration = 3 * 365 * 24 * time.Hour
 	ClustermeshApiserverRemoteCertSecretName       = "clustermesh-apiserver-remote-cert"

--- a/internal/option/config.go
+++ b/internal/option/config.go
@@ -77,6 +77,10 @@ const (
 	ClustermeshApiserverClientCertValidityDuration = "clustermesh-apiserver-client-cert-validity-duration"
 	ClustermeshApiserverClientCertSecretName       = "clustermesh-apiserver-client-cert-secret-name"
 
+	ClustermeshApiserverRemoteCertCommonName       = "clustermesh-apiserver-remote-cert-common-name"
+	ClustermeshApiserverRemoteCertValidityDuration = "clustermesh-apiserver-remote-cert-validity-duration"
+	ClustermeshApiserverRemoteCertSecretName       = "clustermesh-apiserver-remote-cert-secret-name"
+
 	K8sKubeConfigPath = "k8s-kubeconfig-path"
 	K8sRequestTimeout = "k8s-request-timeout"
 )
@@ -183,6 +187,13 @@ type CertGenConfig struct {
 	ClustermeshApiserverClientCertValidityDuration time.Duration
 	// ClustermeshApiserverClientCertSecretName where the ClustermeshApiserver client cert and key will be stored
 	ClustermeshApiserverClientCertSecretName string
+
+	// ClustermeshApiserverRemoteCertCommonName is the CN of the ClustermeshApiserver remote cert
+	ClustermeshApiserverRemoteCertCommonName string
+	// ClustermeshApiserverRemoteCertValidityDuration of certificate
+	ClustermeshApiserverRemoteCertValidityDuration time.Duration
+	// ClustermeshApiserverRemoteCertSecretName where the ClustermeshApiserver remote cert and key will be stored
+	ClustermeshApiserverRemoteCertSecretName string
 }
 
 // PopulateFrom populates the config struct with the values provided by vp
@@ -240,4 +251,8 @@ func (c *CertGenConfig) PopulateFrom(vp *viper.Viper) {
 	c.ClustermeshApiserverClientCertCommonName = vp.GetString(ClustermeshApiserverClientCertCommonName)
 	c.ClustermeshApiserverClientCertValidityDuration = vp.GetDuration(ClustermeshApiserverClientCertValidityDuration)
 	c.ClustermeshApiserverClientCertSecretName = vp.GetString(ClustermeshApiserverClientCertSecretName)
+
+	c.ClustermeshApiserverRemoteCertCommonName = vp.GetString(ClustermeshApiserverRemoteCertCommonName)
+	c.ClustermeshApiserverRemoteCertValidityDuration = vp.GetDuration(ClustermeshApiserverRemoteCertValidityDuration)
+	c.ClustermeshApiserverRemoteCertSecretName = vp.GetString(ClustermeshApiserverRemoteCertSecretName)
 }

--- a/internal/option/config.go
+++ b/internal/option/config.go
@@ -59,24 +59,27 @@ const (
 	ClustermeshApiserverCACertFile = "clustermesh-apiserver-ca-cert-file"
 	ClustermeshApiserverCAKeyFile  = "clustermesh-apiserver-ca-key-file"
 
-	ClustermeshApiserverCertsGenerate = "clustermesh-apiserver-certs-generate"
-
+	ClustermeshApiserverCACertGenerate         = "clustermesh-apiserver-ca-cert-generate"
 	ClustermeshApiserverCACertCommonName       = "clustermesh-apiserver-ca-cert-common-name"
 	ClustermeshApiserverCACertValidityDuration = "clustermesh-apiserver-ca-cert-validity-duration"
 	ClustermeshApiserverCACertSecretName       = "clustermesh-apiserver-ca-cert-secret-name"
 
+	ClustermeshApiserverServerCertGenerate         = "clustermesh-apiserver-server-cert-generate"
 	ClustermeshApiserverServerCertCommonName       = "clustermesh-apiserver-server-cert-common-name"
 	ClustermeshApiserverServerCertValidityDuration = "clustermesh-apiserver-server-cert-validity-duration"
 	ClustermeshApiserverServerCertSecretName       = "clustermesh-apiserver-server-cert-secret-name"
 
+	ClustermeshApiserverAdminCertGenerate         = "clustermesh-apiserver-admin-cert-generate"
 	ClustermeshApiserverAdminCertCommonName       = "clustermesh-apiserver-admin-cert-common-name"
 	ClustermeshApiserverAdminCertValidityDuration = "clustermesh-apiserver-admin-cert-validity-duration"
 	ClustermeshApiserverAdminCertSecretName       = "clustermesh-apiserver-admin-cert-secret-name"
 
+	ClustermeshApiserverClientCertGenerate         = "clustermesh-apiserver-client-cert-generate"
 	ClustermeshApiserverClientCertCommonName       = "clustermesh-apiserver-client-cert-common-name"
 	ClustermeshApiserverClientCertValidityDuration = "clustermesh-apiserver-client-cert-validity-duration"
 	ClustermeshApiserverClientCertSecretName       = "clustermesh-apiserver-client-cert-secret-name"
 
+	ClustermeshApiserverRemoteCertGenerate         = "clustermesh-apiserver-remote-cert-generate"
 	ClustermeshApiserverRemoteCertCommonName       = "clustermesh-apiserver-remote-cert-common-name"
 	ClustermeshApiserverRemoteCertValidityDuration = "clustermesh-apiserver-remote-cert-validity-duration"
 	ClustermeshApiserverRemoteCertSecretName       = "clustermesh-apiserver-remote-cert-secret-name"
@@ -154,12 +157,9 @@ type CertGenConfig struct {
 	// ClustermeshApiserverCAKeyFile is the path to the ClustermeshApiserver CA key PEM (if ClustermeshApiserverCertsGenerate is false)
 	ClustermeshApiserverCAKeyFile string
 
-	// ClustermeshApiserverCertsGenerate can be set to true to generate and store a new ClustermeshApiserver secrets and configmap
-	// New CA ConfigMap is created if created if existing one is not found. Delete the old ConfigMap to force regeneration.
-	// New CA is created if CA cert and key are not given.
-	// Server and client certs are created on each invocation.
-	ClustermeshApiserverCertsGenerate bool
-
+	// ClustermeshApiserverCACertGenerate can be set to true to generate and store a new ClustermeshApiserver CA secret.
+	// New CA secret is created if existing one is not found. Delete the old ConfigMap to force regeneration.
+	ClustermeshApiserverCACertGenerate bool
 	// ClustermeshApiserverCACertCommonName is the CN of the ClustermeshApiserver CA
 	ClustermeshApiserverCACertCommonName string
 	// ClustermeshApiserverCACertValidityDuration of certificate
@@ -167,6 +167,9 @@ type CertGenConfig struct {
 	// ClustermeshApiserverCACertSecretName where the ClustermeshApiserver CA cert will be stored
 	ClustermeshApiserverCACertSecretName string
 
+	// ClustermeshApiserverServerCertGenerate can be set to true to generate and store a new ClustermeshApiserver server secret.
+	// If true then any existing secret is overwritten with a new one.
+	ClustermeshApiserverServerCertGenerate bool
 	// ClustermeshApiserverServerCertCommonName is the CN of the ClustermeshApiserver server cert
 	ClustermeshApiserverServerCertCommonName string
 	// ClustermeshApiserverServerCertValidityDuration of certificate
@@ -174,6 +177,9 @@ type CertGenConfig struct {
 	// ClustermeshApiserverServerCertSecretName where the ClustermeshApiserver server cert and key will be stored
 	ClustermeshApiserverServerCertSecretName string
 
+	// ClustermeshApiserverAdminCertGenerate can be set to true to generate and store a new ClustermeshApiserver admin secret.
+	// If true then any existing secret is overwritten with a new one.
+	ClustermeshApiserverAdminCertGenerate bool
 	// ClustermeshApiserverAdminCertCommonName is the CN of the ClustermeshApiserver admin cert
 	ClustermeshApiserverAdminCertCommonName string
 	// ClustermeshApiserverAdminCertValidityDuration of certificate
@@ -181,6 +187,9 @@ type CertGenConfig struct {
 	// ClustermeshApiserverAdminCertSecretName where the ClustermeshApiserver admin cert and key will be stored
 	ClustermeshApiserverAdminCertSecretName string
 
+	// ClustermeshApiserverClientCertGenerate can be set to true to generate and store a new ClustermeshApiserver client secret.
+	// If true then any existing secret is overwritten with a new one.
+	ClustermeshApiserverClientCertGenerate bool
 	// ClustermeshApiserverClientCertCommonName is the CN of the ClustermeshApiserver client cert
 	ClustermeshApiserverClientCertCommonName string
 	// ClustermeshApiserverClientCertValidityDuration of certificate
@@ -188,6 +197,9 @@ type CertGenConfig struct {
 	// ClustermeshApiserverClientCertSecretName where the ClustermeshApiserver client cert and key will be stored
 	ClustermeshApiserverClientCertSecretName string
 
+	// ClustermeshApiserverRemoteCertGenerate can be set to true to generate and store a new ClustermeshApiserver remote secret.
+	// If true then any existing secret is overwritten with a new one.
+	ClustermeshApiserverRemoteCertGenerate bool
 	// ClustermeshApiserverRemoteCertCommonName is the CN of the ClustermeshApiserver remote cert
 	ClustermeshApiserverRemoteCertCommonName string
 	// ClustermeshApiserverRemoteCertValidityDuration of certificate
@@ -234,24 +246,27 @@ func (c *CertGenConfig) PopulateFrom(vp *viper.Viper) {
 	c.ClustermeshApiserverCACertFile = vp.GetString(ClustermeshApiserverCACertFile)
 	c.ClustermeshApiserverCAKeyFile = vp.GetString(ClustermeshApiserverCAKeyFile)
 
-	c.ClustermeshApiserverCertsGenerate = vp.GetBool(ClustermeshApiserverCertsGenerate)
-
+	c.ClustermeshApiserverCACertGenerate = vp.GetBool(ClustermeshApiserverCACertGenerate)
 	c.ClustermeshApiserverCACertCommonName = vp.GetString(ClustermeshApiserverCACertCommonName)
 	c.ClustermeshApiserverCACertValidityDuration = vp.GetDuration(ClustermeshApiserverCACertValidityDuration)
 	c.ClustermeshApiserverCACertSecretName = vp.GetString(ClustermeshApiserverCACertSecretName)
 
+	c.ClustermeshApiserverServerCertGenerate = vp.GetBool(ClustermeshApiserverServerCertGenerate)
 	c.ClustermeshApiserverServerCertCommonName = vp.GetString(ClustermeshApiserverServerCertCommonName)
 	c.ClustermeshApiserverServerCertValidityDuration = vp.GetDuration(ClustermeshApiserverServerCertValidityDuration)
 	c.ClustermeshApiserverServerCertSecretName = vp.GetString(ClustermeshApiserverServerCertSecretName)
 
+	c.ClustermeshApiserverAdminCertGenerate = vp.GetBool(ClustermeshApiserverAdminCertGenerate)
 	c.ClustermeshApiserverAdminCertCommonName = vp.GetString(ClustermeshApiserverAdminCertCommonName)
 	c.ClustermeshApiserverAdminCertValidityDuration = vp.GetDuration(ClustermeshApiserverAdminCertValidityDuration)
 	c.ClustermeshApiserverAdminCertSecretName = vp.GetString(ClustermeshApiserverAdminCertSecretName)
 
+	c.ClustermeshApiserverClientCertGenerate = vp.GetBool(ClustermeshApiserverClientCertGenerate)
 	c.ClustermeshApiserverClientCertCommonName = vp.GetString(ClustermeshApiserverClientCertCommonName)
 	c.ClustermeshApiserverClientCertValidityDuration = vp.GetDuration(ClustermeshApiserverClientCertValidityDuration)
 	c.ClustermeshApiserverClientCertSecretName = vp.GetString(ClustermeshApiserverClientCertSecretName)
 
+	c.ClustermeshApiserverRemoteCertGenerate = vp.GetBool(ClustermeshApiserverRemoteCertGenerate)
 	c.ClustermeshApiserverRemoteCertCommonName = vp.GetString(ClustermeshApiserverRemoteCertCommonName)
 	c.ClustermeshApiserverRemoteCertValidityDuration = vp.GetDuration(ClustermeshApiserverRemoteCertValidityDuration)
 	c.ClustermeshApiserverRemoteCertSecretName = vp.GetString(ClustermeshApiserverRemoteCertSecretName)


### PR DESCRIPTION
Add generation of clustermesh remote cluster cert.

Also change to not copy CA cert in other clustermesh-apiserver certs, generate all requested certs before storing any, and add individual flags for clustermesh-apiserver certs.
