### PR TITLE
cmd: Use --cilium-namespace as the default for Hubble certs

### DIFF
--- a/cmd/certgen.go
+++ b/cmd/certgen.go
@@ -76,25 +76,25 @@ func New() *cobra.Command {
 	flags.String(option.HubbleCACommonName, defaults.HubbleCACommonName, "Hubble CA common name")
 	flags.Duration(option.HubbleCAValidityDuration, defaults.HubbleCAValidityDuration, "Hubble CA validity duration")
 	flags.String(option.HubbleCAConfigMapName, defaults.HubbleCAConfigMapName, "Name of the K8s ConfigMap where the Hubble CA cert is stored in")
-	flags.String(option.HubbleCAConfigMapNamespace, defaults.HubbleCAConfigMapNamespace, "Namespace of the ConfigMap where the Hubble CA cert is stored in")
+	flags.String(option.HubbleCAConfigMapNamespace, "", "Overwrites the namespace of the ConfigMap where the Hubble CA cert is stored in")
 
 	flags.Bool(option.HubbleRelayClientCertGenerate, defaults.HubbleRelayClientCertGenerate, "Generate and store Hubble Relay client certificate")
 	flags.String(option.HubbleRelayClientCertCommonName, defaults.HubbleRelayClientCertCommonName, "Hubble Relay client certificate common name")
 	flags.Duration(option.HubbleRelayClientCertValidityDuration, defaults.HubbleRelayClientCertValidityDuration, "Hubble Relay client certificate validity duration")
 	flags.String(option.HubbleRelayClientCertSecretName, defaults.HubbleRelayClientCertSecretName, "Name of the K8s Secret where the Hubble Relay client cert and key are stored in")
-	flags.String(option.HubbleRelayClientCertSecretNamespace, defaults.HubbleRelayClientCertSecretNamespace, "Namespace of the K8s Secret where the Hubble Relay client cert and key are stored in")
+	flags.String(option.HubbleRelayClientCertSecretNamespace, "", "Overwrites the namespace of the K8s Secret where the Hubble Relay client cert and key are stored in")
 
 	flags.Bool(option.HubbleRelayServerCertGenerate, defaults.HubbleRelayServerCertGenerate, "Generate and store Hubble Relay server certificate")
 	flags.String(option.HubbleRelayServerCertCommonName, defaults.HubbleRelayServerCertCommonName, "Hubble Relay server certificate common name")
 	flags.Duration(option.HubbleRelayServerCertValidityDuration, defaults.HubbleRelayServerCertValidityDuration, "Hubble Relay server certificate validity duration")
 	flags.String(option.HubbleRelayServerCertSecretName, defaults.HubbleRelayServerCertSecretName, "Name of the K8s Secret where the Hubble Relay server cert and key are stored in")
-	flags.String(option.HubbleRelayServerCertSecretNamespace, defaults.HubbleRelayServerCertSecretNamespace, "Namespace of the K8s Secret where the Hubble Relay server cert and key are stored in")
+	flags.String(option.HubbleRelayServerCertSecretNamespace, "", "Overwrites the namespace of the K8s Secret where the Hubble Relay server cert and key are stored in")
 
 	flags.Bool(option.HubbleServerCertGenerate, defaults.HubbleServerCertGenerate, "Generate and store Hubble server certificate")
 	flags.String(option.HubbleServerCertCommonName, defaults.HubbleServerCertCommonName, "Hubble server certificate common name")
 	flags.Duration(option.HubbleServerCertValidityDuration, defaults.HubbleServerCertValidityDuration, "Hubble server certificate validity duration")
 	flags.String(option.HubbleServerCertSecretName, defaults.HubbleServerCertSecretName, "Name of the K8s Secret where the Hubble server cert and key are stored in")
-	flags.String(option.HubbleServerCertSecretNamespace, defaults.HubbleServerCertSecretNamespace, "Namespace of the K8s Secret where the Hubble server cert and key are stored in")
+	flags.String(option.HubbleServerCertSecretNamespace, "", "Overwrites the namespace of the K8s Secret where the Hubble server cert and key are stored in")
 
 	// Extenal Workload certs
 	flags.String(option.CiliumNamespace, defaults.CiliumNamespace, "Namespace where the cert secrets and configmaps are stored in")

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -19,29 +19,25 @@ import "time"
 const (
 	Debug = false
 
-	HubbleCAGenerate           = false
-	HubbleCACommonName         = "hubble-ca.cilium.io"
-	HubbleCAValidityDuration   = 3 * 365 * 24 * time.Hour
-	HubbleCAConfigMapName      = "hubble-ca-cert"
-	HubbleCAConfigMapNamespace = "kube-system"
+	HubbleCAGenerate         = false
+	HubbleCACommonName       = "hubble-ca.cilium.io"
+	HubbleCAValidityDuration = 3 * 365 * 24 * time.Hour
+	HubbleCAConfigMapName    = "hubble-ca-cert"
 
 	HubbleServerCertGenerate         = false
 	HubbleServerCertCommonName       = "*.default.hubble-grpc.cilium.io"
 	HubbleServerCertValidityDuration = 3 * 365 * 24 * time.Hour
 	HubbleServerCertSecretName       = "hubble-server-certs"
-	HubbleServerCertSecretNamespace  = "kube-system"
 
 	HubbleRelayServerCertGenerate         = false
 	HubbleRelayServerCertCommonName       = "*.hubble-relay.cilium.io"
 	HubbleRelayServerCertValidityDuration = 3 * 365 * 24 * time.Hour
 	HubbleRelayServerCertSecretName       = "hubble-relay-server-certs"
-	HubbleRelayServerCertSecretNamespace  = "kube-system"
 
 	HubbleRelayClientCertGenerate         = false
 	HubbleRelayClientCertCommonName       = "*.hubble-relay.cilium.io"
 	HubbleRelayClientCertValidityDuration = 3 * 365 * 24 * time.Hour
 	HubbleRelayClientCertSecretName       = "hubble-relay-client-certs"
-	HubbleRelayClientCertSecretNamespace  = "kube-system"
 
 	CiliumNamespace = "kube-system"
 

--- a/internal/option/config.go
+++ b/internal/option/config.go
@@ -208,6 +208,16 @@ type CertGenConfig struct {
 	ClustermeshApiserverRemoteCertSecretName string
 }
 
+// getStringWithFallback returns the value associated with the key as a string
+// if it is non-empty. If the value is empty, this function returns the value
+// associated with fallbackKey
+func getStringWithFallback(vp *viper.Viper, key, fallbackKey string) string {
+	if value := vp.GetString(key); value != "" {
+		return value
+	}
+	return vp.GetString(fallbackKey)
+}
+
 // PopulateFrom populates the config struct with the values provided by vp
 func (c *CertGenConfig) PopulateFrom(vp *viper.Viper) {
 	c.Debug = vp.GetBool(Debug)
@@ -221,25 +231,25 @@ func (c *CertGenConfig) PopulateFrom(vp *viper.Viper) {
 	c.HubbleCACommonName = vp.GetString(HubbleCACommonName)
 	c.HubbleCAValidityDuration = vp.GetDuration(HubbleCAValidityDuration)
 	c.HubbleCAConfigMapName = vp.GetString(HubbleCAConfigMapName)
-	c.HubbleCAConfigMapNamespace = vp.GetString(HubbleCAConfigMapNamespace)
+	c.HubbleCAConfigMapNamespace = getStringWithFallback(vp, HubbleCAConfigMapNamespace, CiliumNamespace)
 
 	c.HubbleRelayClientCertGenerate = vp.GetBool(HubbleRelayClientCertGenerate)
 	c.HubbleRelayClientCertCommonName = vp.GetString(HubbleRelayClientCertCommonName)
 	c.HubbleRelayClientCertValidityDuration = vp.GetDuration(HubbleRelayClientCertValidityDuration)
 	c.HubbleRelayClientCertSecretName = vp.GetString(HubbleRelayClientCertSecretName)
-	c.HubbleRelayClientCertSecretNamespace = vp.GetString(HubbleRelayClientCertSecretNamespace)
+	c.HubbleRelayClientCertSecretNamespace = getStringWithFallback(vp, HubbleRelayClientCertSecretNamespace, CiliumNamespace)
 
 	c.HubbleRelayServerCertGenerate = vp.GetBool(HubbleRelayServerCertGenerate)
 	c.HubbleRelayServerCertCommonName = vp.GetString(HubbleRelayServerCertCommonName)
 	c.HubbleRelayServerCertValidityDuration = vp.GetDuration(HubbleRelayServerCertValidityDuration)
 	c.HubbleRelayServerCertSecretName = vp.GetString(HubbleRelayServerCertSecretName)
-	c.HubbleRelayServerCertSecretNamespace = vp.GetString(HubbleRelayServerCertSecretNamespace)
+	c.HubbleRelayServerCertSecretNamespace = getStringWithFallback(vp, HubbleRelayServerCertSecretNamespace, CiliumNamespace)
 
 	c.HubbleServerCertGenerate = vp.GetBool(HubbleServerCertGenerate)
 	c.HubbleServerCertCommonName = vp.GetString(HubbleServerCertCommonName)
 	c.HubbleServerCertValidityDuration = vp.GetDuration(HubbleServerCertValidityDuration)
 	c.HubbleServerCertSecretName = vp.GetString(HubbleServerCertSecretName)
-	c.HubbleServerCertSecretNamespace = vp.GetString(HubbleServerCertSecretNamespace)
+	c.HubbleServerCertSecretNamespace = getStringWithFallback(vp, HubbleServerCertSecretNamespace, CiliumNamespace)
 
 	c.CiliumNamespace = vp.GetString(CiliumNamespace)
 


### PR DESCRIPTION
This change makes `--cilium-namespace` the default namespace of all
secrets and configmaps.

One can still overwrite the namespace value of the Hubble specific
secrets or configmaps by explicitly setting `--hubble-*-namespace`. This
means that an explicitly set `--hubble-*-namespace` always takes
precendece over `--cilium-namespace`.

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>