### PR TITLE
Introduce flag to control CA secret reuse

### DIFF
--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -20,9 +20,13 @@ const (
 	Debug = false
 
 	HubbleCAGenerate         = false
+	HubbleCAReuseSecret      = false
 	HubbleCACommonName       = "hubble-ca.cilium.io"
 	HubbleCAValidityDuration = 3 * 365 * 24 * time.Hour
-	HubbleCAConfigMapName    = "hubble-ca-cert"
+	HubbleCASecretName       = "hubble-ca-secret"
+
+	HubbleCAConfigMapCreate = false
+	HubbleCAConfigMapName   = "hubble-ca-cert"
 
 	HubbleServerCertGenerate         = false
 	HubbleServerCertCommonName       = "*.default.hubble-grpc.cilium.io"
@@ -42,6 +46,7 @@ const (
 	CiliumNamespace = "kube-system"
 
 	ClustermeshApiserverCACertGenerate         = false
+	ClustermeshApiserverCACertReuseSecret      = false
 	ClustermeshApiserverCACertCommonName       = "clustermesh-apiserver-ca.cilium.io"
 	ClustermeshApiserverCACertValidityDuration = 3 * 365 * 24 * time.Hour
 	ClustermeshApiserverCACertSecretName       = "clustermesh-apiserver-ca-cert"


### PR DESCRIPTION
This change revamps the way CA secrets are used for both the Hubble and
the clustermesh-apiserver certificate authority. Now, in order for the
CA secret to be loaded from K8s (instead of generated from scratch), one
needs to provide the `--$CA-reuse-secret` flag.

The overall motivation for this change is twofold. First, it fixes a bug
where certgen would always try to load the clustermesh-apiserver-ca
secret (even if no clustermesh-apiserver certificates were requested).
Second, it tries to unify the behavior between the Hubble CA and the
clustermesh-apiserver CA.

If `--$CA-reuse-secret` is combined with the `--$CA-generate` flag, then
certgen tries to reuse an existing K8s secret before generating a new
CA. This is matches the previous behavior for the clustermesh-apiserver
CA.

If only `--$CA-generate` is provied, then a new CA is generated each
time and any existing secret is overwritten. This is similar to the
previous behavior of the Hubble CA.

If only `--$CA-reuse-secret` is provied, then the CA secret needs to be
present for other certificates to be generated.

In addition, the Hubble CA is now also always stored as a K8s secret by
default, to further unify the behavior of the two CAs. For the Hubble
CA, a new `--hubble-ca-config-map-create` flag is introduced to allow
the additional creation of the ConfigMap containing only the CA public
key.

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>