### PR TITLE
generate: add ca.crt to tls secrets

### DIFF
--- a/cmd/certgen.go
+++ b/cmd/certgen.go
@@ -217,7 +217,7 @@ func generateCertificates() error {
 			option.Config.HubbleServerCertSecretName,
 			option.Config.HubbleServerCertSecretNamespace,
 		)
-		err := hubbleServerCert.Generate(hubbleCA.CACert, hubbleCA.CAKey)
+		err := hubbleServerCert.Generate(hubbleCA)
 		if err != nil {
 			return fmt.Errorf("failed to generate Hubble server cert: %w", err)
 		}
@@ -233,7 +233,7 @@ func generateCertificates() error {
 			option.Config.HubbleRelayClientCertSecretName,
 			option.Config.HubbleRelayClientCertSecretNamespace,
 		)
-		err := hubbleRelayClientCert.Generate(hubbleCA.CACert, hubbleCA.CAKey)
+		err := hubbleRelayClientCert.Generate(hubbleCA)
 		if err != nil {
 			return fmt.Errorf("failed to generate Hubble Relay client cert: %w", err)
 		}
@@ -249,7 +249,7 @@ func generateCertificates() error {
 			option.Config.HubbleRelayServerCertSecretName,
 			option.Config.HubbleRelayServerCertSecretNamespace,
 		)
-		err := hubbleRelayServerCert.Generate(hubbleCA.CACert, hubbleCA.CAKey)
+		err := hubbleRelayServerCert.Generate(hubbleCA)
 		if err != nil {
 			return fmt.Errorf("failed to generate Hubble Relay server cert: %w", err)
 		}
@@ -296,7 +296,7 @@ func generateCertificates() error {
 			option.Config.ClustermeshApiserverServerCertSecretName,
 			option.Config.CiliumNamespace,
 		).WithHosts([]string{option.Config.ClustermeshApiserverServerCertCommonName, "127.0.0.1"})
-		err = clustermeshApiserverServerCert.Generate(clustermeshApiserverCA.CACert, clustermeshApiserverCA.CAKey)
+		err = clustermeshApiserverServerCert.Generate(clustermeshApiserverCA)
 		if err != nil {
 			return fmt.Errorf("failed to generate ClustermeshApiserver server cert: %w", err)
 		}
@@ -312,7 +312,7 @@ func generateCertificates() error {
 			option.Config.ClustermeshApiserverAdminCertSecretName,
 			option.Config.CiliumNamespace,
 		).WithHosts([]string{"localhost"})
-		err = clustermeshApiserverAdminCert.Generate(clustermeshApiserverCA.CACert, clustermeshApiserverCA.CAKey)
+		err = clustermeshApiserverAdminCert.Generate(clustermeshApiserverCA)
 		if err != nil {
 			return fmt.Errorf("failed to generate ClustermeshApiserver admin cert: %w", err)
 		}
@@ -328,7 +328,7 @@ func generateCertificates() error {
 			option.Config.ClustermeshApiserverClientCertSecretName,
 			option.Config.CiliumNamespace,
 		)
-		err = clustermeshApiserverClientCert.Generate(clustermeshApiserverCA.CACert, clustermeshApiserverCA.CAKey)
+		err = clustermeshApiserverClientCert.Generate(clustermeshApiserverCA)
 		if err != nil {
 			return fmt.Errorf("failed to generate ClustermeshApiserver client cert: %w", err)
 		}
@@ -344,7 +344,7 @@ func generateCertificates() error {
 			option.Config.ClustermeshApiserverRemoteCertSecretName,
 			option.Config.CiliumNamespace,
 		)
-		err = clustermeshApiserverRemoteCert.Generate(clustermeshApiserverCA.CACert, clustermeshApiserverCA.CAKey)
+		err = clustermeshApiserverRemoteCert.Generate(clustermeshApiserverCA)
 		if err != nil {
 			return fmt.Errorf("failed to generate ClustermeshApiserver remote cert: %w", err)
 		}

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -81,7 +81,7 @@ func (c *Cert) WithHosts(hosts []string) *Cert {
 }
 
 // Generate the certificate and keyfile and populate c.CertBytes and c.CertKey
-func (c *Cert) Generate(ca *x509.Certificate, caSigner crypto.Signer) error {
+func (c *Cert) Generate(ca *CA) error {
 	log.WithFields(logrus.Fields{
 		logfields.CertCommonName:       c.CommonName,
 		logfields.CertValidityDuration: c.ValidityDuration,
@@ -106,7 +106,8 @@ func (c *Cert) Generate(ca *x509.Certificate, caSigner crypto.Signer) error {
 			Expiry: c.ValidityDuration,
 		},
 	}
-	s, err := local.NewSigner(caSigner, ca, signer.DefaultSigAlgo(caSigner), policy)
+	caCert, caSigner := ca.CACert, ca.CAKey
+	s, err := local.NewSigner(caSigner, caCert, signer.DefaultSigAlgo(caSigner), policy)
 	if err != nil {
 		return err
 	}

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -52,6 +52,7 @@ type Cert struct {
 	Namespace        string
 	Hosts            []string
 
+	CA        *CA
 	CertBytes []byte
 	KeyBytes  []byte
 }
@@ -118,6 +119,7 @@ func (c *Cert) Generate(ca *CA) error {
 		return err
 	}
 
+	c.CA = ca
 	c.CertBytes = certBytes
 	c.KeyBytes = keyBytes
 	return nil
@@ -142,6 +144,7 @@ func (c *Cert) StoreAsSecret(ctx context.Context, k8sClient *kubernetes.Clientse
 			Namespace: c.Namespace,
 		},
 		Data: map[string][]byte{
+			"ca.crt":  c.CA.CACertBytes,
 			"tls.crt": c.CertBytes,
 			"tls.key": c.KeyBytes,
 		},


### PR DESCRIPTION
In an effort to minimize friction and integration with [cert-manager](https://cert-manager.io/), we're aiming to generate the TLS Secrets with the same `data` keys as it does.

The only missing `data` key is `ca.crt` which is the Certificate of the Authority that signed the TLS certificate in `tls.crt`. This PR populate the `ca.crt` key in `data` accordingly.