### PR TITLE
ci: use git status instead of git diff to check for a clean state

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,9 +21,13 @@ jobs:
         run: |
           go fmt ./...
           go vet ./...
+          git diff --exit-code
+      - name: Go mod check
+        working-directory: src/github.com/cilium/certgen
+        run: |
           go mod tidy
           go mod vendor
-          git diff --exit-code
+          test -z "$(git status --porcelain)" || (echo "please run 'go mod tidy && go mod vendor', and submit your changes"; exit 1)
       - name: Build
         working-directory: src/github.com/cilium/certgen
         run: |


### PR DESCRIPTION
Before this patch, git diff was used to ensure a clean state with respect to the git repository. While it could catch a modified or removed file, it would not fail when a file was not checked in git (i.e. untracked).

This patch uses git status instead of git diff, effectively catching untracked files as well.
