### PR TITLE
certgen: include '*.mesh.cilium.io' in server cert

### DIFF
--- a/cmd/certgen.go
+++ b/cmd/certgen.go
@@ -117,6 +117,7 @@ func New() *cobra.Command {
 	flags.String(option.ClustermeshApiserverServerCertCommonName, defaults.ClustermeshApiserverServerCertCommonName, "clustermesh-apiserver server certificate common name")
 	flags.Duration(option.ClustermeshApiserverServerCertValidityDuration, defaults.ClustermeshApiserverServerCertValidityDuration, "clustermesh-apiserver server certificate validity duration")
 	flags.String(option.ClustermeshApiserverServerCertSecretName, defaults.ClustermeshApiserverServerCertSecretName, "Name of the K8s Secret where the clustermesh-apiserver server cert and key are stored in")
+	flags.StringSlice(option.ClustermeshApiserverServerCertSANs, defaults.ClustermeshApiserverServerCertSANs, "clustermesh-apiserver server certificate SANs")
 
 	flags.Bool(option.ClustermeshApiserverAdminCertGenerate, defaults.ClustermeshApiserverAdminCertGenerate, "Generate and store clustermesh-apiserver admin certificate")
 	flags.String(option.ClustermeshApiserverAdminCertCommonName, defaults.ClustermeshApiserverAdminCertCommonName, "clustermesh-apiserver admin certificate common name")
@@ -295,7 +296,12 @@ func generateCertificates() error {
 			defaults.ClustermeshApiserverCertUsage,
 			option.Config.ClustermeshApiserverServerCertSecretName,
 			option.Config.CiliumNamespace,
-		).WithHosts([]string{option.Config.ClustermeshApiserverServerCertCommonName, "127.0.0.1"})
+		).WithHosts(
+			append([]string{
+				option.Config.ClustermeshApiserverServerCertCommonName,
+				"127.0.0.1",
+			}, option.Config.ClustermeshApiserverServerCertSANs...),
+		)
 		err = clustermeshApiserverServerCert.Generate(clustermeshApiserverCA)
 		if err != nil {
 			return fmt.Errorf("failed to generate ClustermeshApiserver server cert: %w", err)

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -80,4 +80,6 @@ var (
 	HubbleRelayClientCertUsage = []string{"signing", "key encipherment", "server auth", "client auth"}
 
 	ClustermeshApiserverCertUsage = []string{"signing", "key encipherment", "server auth", "client auth"}
+
+	ClustermeshApiserverServerCertSANs = []string{"*.mesh.cilium.io"}
 )

--- a/internal/option/config.go
+++ b/internal/option/config.go
@@ -74,6 +74,7 @@ const (
 	ClustermeshApiserverServerCertCommonName       = "clustermesh-apiserver-server-cert-common-name"
 	ClustermeshApiserverServerCertValidityDuration = "clustermesh-apiserver-server-cert-validity-duration"
 	ClustermeshApiserverServerCertSecretName       = "clustermesh-apiserver-server-cert-secret-name"
+	ClustermeshApiserverServerCertSANs             = "clustermesh-apiserver-server-cert-sans"
 
 	ClustermeshApiserverAdminCertGenerate         = "clustermesh-apiserver-admin-cert-generate"
 	ClustermeshApiserverAdminCertCommonName       = "clustermesh-apiserver-admin-cert-common-name"
@@ -196,6 +197,8 @@ type CertGenConfig struct {
 	ClustermeshApiserverServerCertValidityDuration time.Duration
 	// ClustermeshApiserverServerCertSecretName where the ClustermeshApiserver server cert and key will be stored
 	ClustermeshApiserverServerCertSecretName string
+	// ClustermeshApiserverServerCertSANs is the list of SANs to add to the clustermesh-apiserver server certificate.
+	ClustermeshApiserverServerCertSANs []string
 
 	// ClustermeshApiserverAdminCertGenerate can be set to true to generate and store a new ClustermeshApiserver admin secret.
 	// If true then any existing secret is overwritten with a new one.
@@ -291,6 +294,7 @@ func (c *CertGenConfig) PopulateFrom(vp *viper.Viper) {
 	c.ClustermeshApiserverServerCertCommonName = vp.GetString(ClustermeshApiserverServerCertCommonName)
 	c.ClustermeshApiserverServerCertValidityDuration = vp.GetDuration(ClustermeshApiserverServerCertValidityDuration)
 	c.ClustermeshApiserverServerCertSecretName = vp.GetString(ClustermeshApiserverServerCertSecretName)
+	c.ClustermeshApiserverServerCertSANs = vp.GetStringSlice(ClustermeshApiserverServerCertSANs)
 
 	c.ClustermeshApiserverAdminCertGenerate = vp.GetBool(ClustermeshApiserverAdminCertGenerate)
 	c.ClustermeshApiserverAdminCertCommonName = vp.GetString(ClustermeshApiserverAdminCertCommonName)


### PR DESCRIPTION
Includes `*.mesh.cilium.io` by default in the list of SANs for the clustermesh-apiserver server certificate. The value is made configurable in case users want to override it or restrict to a specific subset.