### PR TITLE
Update Go and drop explicit `go vet` check

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2.1.4
         with:
-          go-version: 1.17.0
+          go-version: 1.17.1
       - name: Checkout code
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,11 +16,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: src/github.com/cilium/certgen
-      - name: Lint
+      - name: Formatting check
         working-directory: src/github.com/cilium/certgen
         run: |
           go fmt ./...
-          go vet ./...
           git diff --exit-code
       - name: Go mod check
         working-directory: src/github.com/cilium/certgen

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 ARG BASE_IMAGE=scratch
 
-FROM docker.io/library/golang:1.17.0 as builder
+FROM docker.io/library/golang:1.17.1 as builder
 ADD . /go/src/github.com/cilium/certgen
 WORKDIR /go/src/github.com/cilium/certgen
 RUN CGO_ENABLED=0 go build -o cilium-certgen main.go


### PR DESCRIPTION
Update Go to 1.17.1 and drop the explicit `go vet` invocation. The `go test` command will automatically run `go vet` on all packages  being tested as of Go 1.10, see https://golang.org/doc/go1.10#test