### PR TITLE
cmd: deprecate the hubble ca configmap related flags

### DIFF
--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -255,38 +255,6 @@ func (c *CA) LoadFromFile(caCertFile, caKeyFile string) error {
 	return c.loadKeyPair()
 }
 
-// StoreAsConfigMap creates or updates the CA certificate in a K8s configmap
-func (c *CA) StoreAsConfigMap(ctx context.Context, k8sClient *kubernetes.Clientset) error {
-	if c.CACertBytes == nil || c.CAKeyBytes == nil {
-		return fmt.Errorf("cannot create configmap %s/%s from empty certificate",
-			c.ConfigMapNamespace, c.ConfigMapName)
-	}
-
-	scopedLog := log.WithFields(logrus.Fields{
-		logfields.K8sConfigMapNamespace: c.ConfigMapNamespace,
-		logfields.K8sConfigMapName:      c.ConfigMapName,
-	})
-	scopedLog.Info("Creating K8s ConfigMap")
-
-	configMap := &v1.ConfigMap{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      c.ConfigMapName,
-			Namespace: c.ConfigMapNamespace,
-		},
-		BinaryData: map[string][]byte{
-			"ca.crt": c.CACertBytes,
-		},
-	}
-
-	k8sConfigMaps := k8sClient.CoreV1().ConfigMaps(c.ConfigMapNamespace)
-	_, err := k8sConfigMaps.Create(ctx, configMap, meta_v1.CreateOptions{})
-	if k8sErrors.IsAlreadyExists(err) {
-		scopedLog.Info("ConfigMap already exists, updating it instead")
-		_, err = k8sConfigMaps.Update(ctx, configMap, meta_v1.UpdateOptions{})
-	}
-	return err
-}
-
 // StoreAsSecret creates or updates the CA certificate in a K8s secret
 func (c *CA) StoreAsSecret(ctx context.Context, k8sClient *kubernetes.Clientset) error {
 	if c.CACertBytes == nil || c.CAKeyBytes == nil {


### PR DESCRIPTION
The Hubble CA ConfigMap has been deprecated in Cilium v1.10 and removed from v1.11.

See https://github.com/cilium/certgen/pull/41#discussion_r761204425 for context.