### PR TITLE
bug: Avoid race condition while generate secret with re-use flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# certgen binary
+certgen


### PR DESCRIPTION
### Description

There might be a race condition if multiple certgen processes are running
at the same time with ca-reuse-secret and ca-generate flags enabled. The
sequence of flows could be as below:

P1 -> Confirm secret is not available
P2 -> Confirm secret is not available
P1 -> Generate new CA
P2 -> Generate new CA
P1 -> Store its generate CA to secret
P2 -> Store its generate CA to secret, which overwrite what P1 stored.

This commit is to make sure that we will throw IsAlreadyExists error if
the secret is available in StoreAsSecret function, then the caller (e.g
certgen) will decide if it should fail or just reload secret and proceed.
In above example, P2 will reload CA from secret accordingly.

Signed-off-by: Tam Mach <tam.mach@isovalent.com>

### Background

This is coming out of sync between myself, Sebastian and Alex on PR https://github.com/cilium/cilium/pull/18607

### Testing

Testing was done by running two certgen with same arguments at the same time

<details>
<summary>Running 2 certgen at the same time</summary>

```
$ cat ./temp.sh                                                  
./certgen --cilium-namespace=kube-system \
  --ca-generate \
  --ca-reuse-secret \
  --hubble-server-cert-generate \
  --hubble-server-cert-validity-duration=94608000s \
  --hubble-relay-client-cert-generate \
  --hubble-relay-client-cert-validity-duration=94608000s \
  --hubble-server-cert-common-name="*.default.hubble-grpc.cilium.io" \
  --k8s-kubeconfig-path=/home/tammach/.kube/config &

./certgen --cilium-namespace=kube-system \
  --ca-generate \
  --ca-reuse-secret \
  --hubble-server-cert-generate \
  --hubble-server-cert-validity-duration=94608000s \
  --hubble-relay-client-cert-generate \
  --hubble-relay-client-cert-validity-duration=94608000s \
  --hubble-server-cert-common-name="*.default.hubble-grpc.cilium.io" \
  --k8s-kubeconfig-path=/home/tammach/.kube/config &

$ ./temp.sh

$ INFO[0000] Generating server certificates for Hubble     subsys=cilium-certgen
INFO[0000] Creating CSR for certificate                  certCommonName="*.default.hubble-grpc.cilium.io" certUsage="[signing key encipherment server auth]" certValidityDuration=26280h0m0s subsys=generate
INFO[0000] generate received request                     subsys=cfssl syslog=info
INFO[0000] received CSR                                  subsys=cfssl syslog=info
INFO[0000] generating key: ecdsa-256                     subsys=cfssl syslog=info
INFO[0000] encoded CSR                                   subsys=cfssl syslog=info
INFO[0000] signed certificate with serial number 221515214984934946033776608488653915802833225245  subsys=cfssl syslog=info
INFO[0000] Generating client certificates for Hubble Relay  subsys=cilium-certgen
INFO[0000] Creating CSR for certificate                  certCommonName="*.hubble-relay.cilium.io" certUsage="[signing key encipherment server auth client auth]" certValidityDuration=26280h0m0s subsys=generate
INFO[0000] generate received request                     subsys=cfssl syslog=info
INFO[0000] received CSR                                  subsys=cfssl syslog=info
INFO[0000] generating key: ecdsa-256                     subsys=cfssl syslog=info
INFO[0000] encoded CSR                                   subsys=cfssl syslog=info
INFO[0000] signed certificate with serial number 171989534383653302175083234562251692908153489523  subsys=cfssl syslog=info
INFO[0000] Creating K8s Secret                           k8sSecretName=hubble-server-certs k8sSecretNamespace=kube-system subsys=generate
WARN[0000] Secret already exists                         k8sSecretName=cilium-ca k8sSecretNamespace=kube-system subsys=generate
INFO[0000] Reload secret for Cilium CA                   subsys=cilium-certgen


```

</details>