### PR TITLE
CODEOWNERS: Fix renamed teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,15 +2,15 @@
 # @cilium/ci-structure       Continuous integration, testing
 # @cilium/contributing       Developer documentation & tools
 # @cilium/github-sec         GitHub security (handling of secrets, consequences of pull_request_target, etc.)
-# @cilium/hubble             All related to Hubble (client and server)
+# @cilium/sig-hubble         All related to Hubble (client and server)
 # @cilium/vendor             Vendoring, dependency management
 
 # The following filepaths should be sorted so that more specific paths occur
 # after the less specific paths, otherwise the ownership for the specific paths
 # is not properly picked up in Github.
-* @cilium/hubble
-/.github/workflows/ @cilium/github-sec @cilium/ci-structure @cilium/hubble
-/CODEOWNERS @cilium/contributing @cilium/hubble
+* @cilium/sig-hubble
+/.github/workflows/ @cilium/github-sec @cilium/ci-structure @cilium/sig-hubble
+/CODEOWNERS @cilium/contributing @cilium/sig-hubble
 /go.sum @cilium/vendor
 /go.mod @cilium/vendor
 /vendor/ @cilium/vendor


### PR DESCRIPTION
Some teams were recently renamed, update the CODEOWNERS to reflect that.
