### PR TITLE
Add support for cross-build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,13 @@
 ARG GOLANG_IMAGE=docker.io/library/golang:1.18.2-alpine3.15@sha256:e6b729ae22a2f7b6afcc237f7b9da3a27151ecbdcd109f7ab63a42e52e750262
 ARG BASE_IMAGE=scratch
 
-FROM ${GOLANG_IMAGE} as builder
+# BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
+FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} as builder
 ADD . /go/src/github.com/cilium/certgen
 WORKDIR /go/src/github.com/cilium/certgen
-RUN CGO_ENABLED=0 go build -o cilium-certgen main.go
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOARCH=${TARGETARCH} go build -o cilium-certgen main.go
 
 FROM ${BASE_IMAGE}
 LABEL maintainer="maintainer@cilium.io"


### PR DESCRIPTION
It makes it possible to build an image for `arm64` (and maybe others) with docker driver:
```
docker buildx build --platform=linux/arm64 .
```