### PR TITLE
ci: fix indentation of golangci-lint action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,10 +26,10 @@ jobs:
       - name: Run static checks
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5
         with:
-        version: v1.52.1
-        # use our .golangci.yml and configure output to be logged in the GHA, in addition to annotating the commit.
-        # see https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648 for output
-        args: --config=.golangci.yml --verbose --out-${NO_FUTURE}format colored-line-number
+          version: v1.52.2
+          # use our .golangci.yml and configure output to be logged in the GHA, in addition to annotating the commit.
+          # see https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648 for output
+          args: --config=.golangci.yml --verbose --out-${NO_FUTURE}format colored-line-number
           skip-cache: true
       - name: Build
         run: |


### PR DESCRIPTION
While here, also bump golangci-lint to v1.52.2.

Fixes: a0e66e12d1bdffa923568e057c0d676deb41aacc