### PR TITLE
ci: increase PR limits for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
     rebase-strategy: "disabled"
     ignore:
         # k8s dependencies will be updated manually all at once
@@ -15,12 +15,12 @@ updates:
     directory: /
     schedule:
       interval: daily
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     rebase-strategy: "disabled"
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: daily
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     rebase-strategy: "disabled"


### PR DESCRIPTION
Dependabot PRs related to GitHub Action updates and Docker updates very rarely conflict. Let's bump the PR limit to 5 for them. Go updates have more probability to conflict but they don't always do either, let's bump the limit to 3.