### PR TITLE
github: Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/build-images-release.yaml
+++ b/.github/workflows/build-images-release.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Getting image tag
         id: tag
         run: |
-          echo ::set-output name=tag::${GITHUB_REF##*/}
+          echo "tag=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
 
       - name: Checkout Source Code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
@@ -91,7 +91,7 @@ jobs:
       - name: Getting image tag
         id: tag
         run: |
-          echo ::set-output name=tag::${GITHUB_REF##*/}
+          echo "tag=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
       - name: Downloading Image Digests
         shell: bash
         run: |


### PR DESCRIPTION
## Description

Update `.github/workflows/build-images-release.yaml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml'  | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: |
  echo ::set-output name=tag::${GITHUB_REF##*/}
```

**TO-BE**

```yml
run: |
  echo "tag=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
```