### PR TITLE
ci: let dependabot update k8s deps as a group of deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,11 @@ updates:
       interval: daily
     open-pull-requests-limit: 3
     rebase-strategy: "disabled"
-    ignore:
-        # k8s dependencies will be updated manually all at once
-      - dependency-name: "k8s.io/*"
-      - dependency-name: "sigs.k8s.io/*"
+    groups:
+      k8s-deps:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Given that this set of dependencies need to be updated at once, they were ignored by dependabot's config. However, with dependabot now having support for grouped updates, we can leverage the feature to let the bot update them all at once.