### PR TITLE
ci: Bump Go to v1.21.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # (first line comment needed for DOCKER_BUILDKIT use)
 #
 # use skopeo inspect to get the multiarch manifest list digest
-# skopeo inspect --override-os linux docker://golang:1.21.4-alpine4.18 | jq -r '.Digest'
-ARG GOLANG_IMAGE=docker.io/library/golang:1.21.4-alpine3.18@sha256:110b07af87238fbdc5f1df52b00927cf58ce3de358eeeb1854f10a8b5e5e1411
+# skopeo inspect --override-os linux docker://golang:1.21.5-alpine3.19 | jq -r '.Digest'
+ARG GOLANG_IMAGE=docker.io/library/golang:1.21.5-alpine3.19@sha256:feceecc0e1d73d085040a8844de11a2858ba4a0c58c16a672f1736daecc2a4ff
 ARG BASE_IMAGE=scratch
 
 FROM ${GOLANG_IMAGE} as builder

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/certgen
 
-go 1.21.4
+go 1.21.5
 
 require (
 	github.com/cloudflare/cfssl v1.6.4


### PR DESCRIPTION
Bump the build base golang image to alpine 3.19 on the way.