### PR TITLE
clustermesh: drop unnecessary localhost SAN from the admin certificate

### DIFF
--- a/cmd/certgen.go
+++ b/cmd/certgen.go
@@ -297,7 +297,7 @@ func generateCertificates() error {
 			defaults.ClustermeshApiserverCertUsage,
 			option.Config.ClustermeshApiserverAdminCertSecretName,
 			option.Config.CiliumNamespace,
-		).WithHosts([]string{"localhost"})
+		).WithHosts(nil /* Don't add the CN as SAN */)
 		err = clustermeshApiserverAdminCert.Generate(ciliumCA)
 		if err != nil {
 			return fmt.Errorf("failed to generate ClustermeshApiserver admin cert: %w", err)
@@ -313,7 +313,7 @@ func generateCertificates() error {
 			defaults.ClustermeshApiserverCertUsage,
 			option.Config.ClustermeshApiserverClientCertSecretName,
 			option.Config.CiliumNamespace,
-		)
+		).WithHosts(nil /* Don't add the CN as SAN */)
 		err = clustermeshApiserverClientCert.Generate(ciliumCA)
 		if err != nil {
 			return fmt.Errorf("failed to generate ClustermeshApiserver client cert: %w", err)
@@ -329,7 +329,7 @@ func generateCertificates() error {
 			defaults.ClustermeshApiserverCertUsage,
 			option.Config.ClustermeshApiserverRemoteCertSecretName,
 			option.Config.CiliumNamespace,
-		)
+		).WithHosts(nil /* Don't add the CN as SAN */)
 		err = clustermeshApiserverRemoteCert.Generate(ciliumCA)
 		if err != nil {
 			return fmt.Errorf("failed to generate ClustermeshApiserver remote cert: %w", err)


### PR DESCRIPTION
The admin certificate is used by the clustermesh-apiserver for client authentication against the sidecar etcd instance. Etcd leverages the common name to determine the user name, while SANs are ignored. Hence, let's just remove it, as not necessary. Additionally, let's do the same for all the other clustermesh client-auth certs, as by default the CN
is copied into the SAN section as well. This is consistent with the behavior of the other Cilium's autogeneration methods.

Related: cilium/cilium#32662