### PR TITLE
prepare for branching v0.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,48 @@
 version: 2
 updates:
+# v0.1 branch configuration
+  - package-ecosystem: gomod
+    directory: /
+    target-branch: "v0.1"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "[v0.1] vendor:"
+    open-pull-requests-limit: 3
+    rebase-strategy: "disabled"
+    groups:
+      k8s-deps:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: "v0.1"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "[v0.1] ci:"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+
+  - package-ecosystem: docker
+    directory: /
+    target-branch: "v0.1"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "[v0.1] docker:"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+
+# main branch configuration
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: daily
+    commit-message:
+      prefix: "vendor:"
     open-pull-requests-limit: 3
     rebase-strategy: "disabled"
     groups:
@@ -16,6 +55,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    commit-message:
+      prefix: "ci:"
     open-pull-requests-limit: 5
     rebase-strategy: "disabled"
 
@@ -23,5 +64,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+    commit-message:
+      prefix: "docker:"
     open-pull-requests-limit: 5
     rebase-strategy: "disabled"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - v0.1
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,9 @@
 
 Release process and checklist for `certgen`.
 
+> [!NOTE]  
+> If this is a v0.1.x maintenance release, be sure to checkout the v0.1 branch first
+
 ## Modify the Version
 
 Update the Version `var` in `internal/version/version.go`


### PR DESCRIPTION
For context, https://github.com/cilium/certgen/pull/220 will introduce a configuration breaking change and after discussion we will maintain patch release v0.1 branch for Cilium < v1.16.

`.github/workflows/build-images-release.yaml` is based on tags and thus should work without modifications. I'm also inclined to change the default branch to `main` instead of the current `master` for consistency with other cilium repository (see https://github.com/cilium/cilium/issues/23110).