### PR TITLE
v0.1: Bump Golang to v1.22.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # use skopeo inspect to get the multiarch manifest list digest
 # skopeo inspect --override-os linux docker://golang:1.22.4-alpine3.19 | jq -r '.Digest'
-ARG GOLANG_IMAGE=docker.io/library/golang:1.22.4-alpine3.19@sha256:65b5d2d0a312fd9ef65551ad7f9cb5db1f209b7517ef6d5625cfd29248bc6c85
+ARG GOLANG_IMAGE=docker.io/library/golang:1.22.5-alpine3.19@sha256:0642d4f809abf039440540de1f0e83502401686e3946ed8e7398a1d94648aa6d
 ARG BASE_IMAGE=scratch
 
 FROM ${GOLANG_IMAGE} as builder

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/certgen
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/cloudflare/cfssl v1.6.5


### PR DESCRIPTION
Backport of #249 to the v0.1 branch.