### PR TITLE
hubble: client auth for hubble server cert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 ARG GOLANG_IMAGE=docker.io/library/golang:1.22.5-alpine3.19@sha256:0642d4f809abf039440540de1f0e83502401686e3946ed8e7398a1d94648aa6d
 ARG BASE_IMAGE=scratch
 
-FROM ${GOLANG_IMAGE} as builder
+FROM ${GOLANG_IMAGE} AS builder
 ADD . /go/src/github.com/cilium/certgen
 WORKDIR /go/src/github.com/cilium/certgen
 RUN CGO_ENABLED=0 go build -o cilium-certgen main.go

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -142,7 +142,7 @@ const (
 var (
 	// HubbleServerCertUsage are the key usages for the Hubble server x509
 	// certificate.
-	HubbleServerCertUsage = []string{"signing", "key encipherment", "server auth"}
+	HubbleServerCertUsage = []string{"signing", "key encipherment", "server auth", "client auth"}
 	// HubbleMetricsServerCertUsage are the key usages for the Hubble metrics
 	// server x509 certificate.
 	HubbleMetricsServerCertUsage = []string{"signing", "key encipherment", "server auth"}


### PR DESCRIPTION
See https://github.com/cilium/cilium/pull/34934, needs to be done in certgen v0.1 to be introduced in Cilium v1.15 and v1.14.