### PR TITLE
[v0.1]: bump Go to v1.24.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # (first line comment needed for DOCKER_BUILDKIT use)
 #
 # use skopeo inspect to get the multiarch manifest list digest
-# skopeo inspect --override-os linux docker://golang:1.23.9-alpine3.21 | jq -r '.Digest'
-ARG GOLANG_IMAGE=docker.io/library/golang:1.23.9-alpine3.21@sha256:fb7ea5cd19bc4eea3eb0d1972919ec0f6229b138985ce4b35ce5846c6bc02973
+# skopeo inspect --override-os linux docker://golang:1.24.3-alpine3.21 | jq -r '.Digest'
+ARG GOLANG_IMAGE=docker.io/library/golang:1.24.3-alpine3.21@sha256:ef18ee7117463ac1055f5a370ed18b8750f01589f13ea0b48642f5792b234044
 ARG BASE_IMAGE=scratch
 
 FROM ${GOLANG_IMAGE} AS builder


### PR DESCRIPTION
Commit e63e7e9f0f0ae1340271b1b3975d5e84187b623b updated the k8s deps to 0.33.0 which require Go v1.24.