### PR TITLE
CODEOWNERS: let certgen team take over responsibility of this project

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,15 +2,15 @@
 # @cilium/ci-structure       Continuous integration, testing
 # @cilium/contributing       Developer documentation & tools
 # @cilium/github-sec         GitHub security (handling of secrets, consequences of pull_request_target, etc.)
-# @cilium/sig-hubble         All related to Hubble (client and server)
+# @cilium/certgen            All things related to certgen
 # @cilium/vendor             Vendoring, dependency management
 
 # The following filepaths should be sorted so that more specific paths occur
 # after the less specific paths, otherwise the ownership for the specific paths
 # is not properly picked up in Github.
-* @cilium/sig-hubble
-/.github/workflows/ @cilium/github-sec @cilium/ci-structure @cilium/sig-hubble
-/CODEOWNERS @cilium/contributing @cilium/sig-hubble
+* @cilium/certgen
+/.github/workflows/ @cilium/github-sec @cilium/ci-structure @cilium/certgen
+/CODEOWNERS @cilium/contributing @cilium/certgen
 /go.sum @cilium/vendor
 /go.mod @cilium/vendor
 /vendor/ @cilium/vendor


### PR DESCRIPTION
Let's update the CODEOWNERS file following the creation of the dedicated @cilium/certgen team \[1], which is intended to take over responsibility for the certgen project from the @cilium/hubble team. All other codeowners are preserved unmodified.

\[1]: cilium/community#322

/cc @cilium/sig-hubble 
/cc @cilium/certgen 