### PR TITLE
cmd: exit with non-zero code in case of errors

### DIFF
--- a/cmd/certgen.go
+++ b/cmd/certgen.go
@@ -52,6 +52,7 @@ func New() (*cobra.Command, error) {
 
 			if err := generateCertificates(log); err != nil {
 				log.Error("failed to generate certificates", "error", err)
+				os.Exit(1)
 			}
 		},
 	}


### PR DESCRIPTION
The blamed commit unintentionally changed the behavior in case of errors, causing the process to return with a zero exit code. However, this is problematic, as it hides failures and prevents retries when e.g., executed as a Kubernetes job. Let's restore the previous behavior, exiting with a non-zero code in that case.

Fixes: 7d1beaa6 ("logging: migrate from logrus to slog")