### PR TITLE
Fix display digest step of build-image-release

### DIFF
--- a/.github/workflows/build-images-release.yaml
+++ b/.github/workflows/build-images-release.yaml
@@ -101,6 +101,7 @@ jobs:
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           path: image-digest/
+          pattern: "*image-digest *"
 
       - name: Image Digests Output
         shell: bash


### PR DESCRIPTION
Same as https://github.com/cilium/cilium/commit/112a16db2270.

Successful run: https://github.com/cilium/certgen/actions/runs/19530449923/job/55913051334?pr=483