### PR TITLE
fix: return a clear error when no CA is configured

### DIFF
--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -76,6 +76,10 @@ func (c *Cert) WithHosts(hosts []string) *Cert {
 
 // Generate the certificate and keyfile and populate c.CertBytes and c.CertKey.
 func (c *Cert) Generate(log *slog.Logger, ca *CA) error {
+	if ca == nil || ca.CAKey == nil || len(ca.CACerts) == 0 {
+		return errors.New("cannot generate certificate without a loaded or generated CA")
+	}
+
 	log.Info("Creating CSR for certificate",
 		logfields.CertCommonName, c.CommonName,
 		logfields.CertValidityDuration, c.ValidityDuration.String(),

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package generate
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// TestCertGenerateRequiresCA verifies generation fails without a usable CA.
+func TestCertGenerateRequiresCA(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	cert := NewCert("test", time.Hour, []string{"server auth"}, "test", "default")
+
+	tests := []struct {
+		name string
+		ca   *CA
+	}{
+		{
+			name: "nil CA",
+			ca:   nil,
+		},
+		{
+			name: "empty CA",
+			ca:   &CA{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := cert.Generate(logger, tt.ca)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+
+			const want = "cannot generate certificate without a loaded or generated CA"
+			if err.Error() != want {
+				t.Fatalf("unexpected error: got %q want %q", err.Error(), want)
+			}
+		})
+	}
+}
+
+// TestCertGenerateWithCA verifies generation succeeds with a CA.
+func TestCertGenerateWithCA(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	ca, err := NewCA(CAConfig{
+		SecretName:      "ca",
+		SecretNamespace: "default",
+	})
+	if err != nil {
+		t.Fatalf("failed to create CA: %v", err)
+	}
+
+	if err := ca.Generate(logger, "test-ca", time.Hour); err != nil {
+		t.Fatalf("failed to generate CA: %v", err)
+	}
+
+	cert := NewCert("test", time.Hour, []string{"server auth"}, "test", "default")
+	if err := cert.Generate(logger, ca); err != nil {
+		t.Fatalf("failed to generate cert: %v", err)
+	}
+
+	if len(cert.CertBytes) == 0 {
+		t.Fatal("expected generated certificate bytes")
+	}
+
+	if len(cert.KeyBytes) == 0 {
+		t.Fatal("expected generated key bytes")
+	}
+}


### PR DESCRIPTION
certgen can panic if you ask it to generate leaf certs without any CA source configured. This is pretty easy to hit in practice: just pass a cert config, but skip `--ca-generate`, `--ca-reuse-secret`, and `--ca-cert-file` plus `--ca-key-file`.

The crash comes from `Cert.Generate()` calling into cfssl with an empty CA. This patch fails fast with a clear error instead, and adds tests for nil CA, empty CA, and the happy path too.

repro:

```bash
cat > /tmp/certgen-repro/certs.yaml <<'EOF2'
certs:
  - name: test
    namespace: default
    commonName: test
    usage:
      - server auth
    validity: 1h
EOF2

go run . --k8s-kubeconfig-path /tmp/certgen-repro/kubeconfig --config-file /tmp/certgen-repro/certs.yaml
```

before: panic in `signer.DefaultSigAlgo`
after: `failed to generate cert: cannot generate certificate without a loaded or generated CA`
