### PR TITLE
fix: correct the CA key file load error message

### DIFF
--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -291,7 +291,7 @@ func (c *CA) LoadFromFile(caCertFile, caKeyFile string) error {
 
 	caKeyBytes, err := os.ReadFile(caKeyFile)
 	if err != nil {
-		return fmt.Errorf("failed to load Hubble CA key file: %w", err)
+		return fmt.Errorf("failed to load CA key file: %w", err)
 	}
 
 	c.CAKeyBytes = caKeyBytes

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -4,7 +4,11 @@
 package generate
 
 import (
+	"errors"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -76,5 +80,39 @@ func TestCertGenerateWithCA(t *testing.T) {
 
 	if len(cert.KeyBytes) == 0 {
 		t.Fatal("expected generated key bytes")
+	}
+}
+
+// TestCALoadFromFileErrors verifies CA file load errors
+// mention the correct path.
+func TestCALoadFromFileErrors(t *testing.T) {
+	t.Parallel()
+
+	ca, err := NewCA(CAConfig{
+		SecretName:      "ca",
+		SecretNamespace: "default",
+	})
+	if err != nil {
+		t.Fatalf("failed to create CA: %v", err)
+	}
+
+	certPath := filepath.Join(t.TempDir(), "ca.crt")
+	if err := os.WriteFile(certPath, []byte("dummy"), 0o600); err != nil {
+		t.Fatalf("failed to write cert file: %v", err)
+	}
+
+	keyPath := filepath.Join(t.TempDir(), "ca.key")
+	err = ca.LoadFromFile(certPath, keyPath)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	const want = "failed to load CA key file"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("unexpected error: got %q want substring %q", err.Error(), want)
+	}
+
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected not-exist error, got %v", err)
 	}
 }


### PR DESCRIPTION
This fixes a weird little paper cut in the CA file loading path.
If the CA key read fails, certgen says `failed to load Hubble CA key file`, which is kinda off for a generic CA path and makes debugging a bad `--ca-key-file` a bit noisy.

This patch swaps that message to `failed to load CA key file` and adds a regression test, thats it.

Repro
1. Run `go test -run TestCALoadFromFileErrors -v ./internal/generate`
2. The test creates a temp cert file and uses a missing key path
3. On `main` this path reports `failed to load Hubble CA key file`
4. With this patch it reports `failed to load CA key file`

Tested with `go test ./...`
