### PR TITLE
fix: avoid panic when updating empty CA ConfigMaps

### DIFF
--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -176,7 +176,17 @@ jobs:
           assert_equal "$(cat bar.ca.crt)" "$(cat ca.crt)"
 
           echo
-          echo "Regenerating certificates"
+          echo "Replacing the CA ConfigMap with an empty placeholder"
+          kubectl apply -f - <<EOF
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: the-ca
+            namespace: weasel
+          EOF
+
+          echo
+          echo "Regenerating certificates with an existing empty ConfigMap"
           CILIUM_CERTGEN_CONFIG="$(cat config.yaml)" ./certgen \
               --k8s-kubeconfig-path=${HOME}/.kube/config \
               --ca-generate --ca-reuse-secret \

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -373,6 +373,9 @@ func (c *CA) StoreAsConfigMap(ctx context.Context, log *slog.Logger, k8sClient *
 	}
 
 	scopedLog.Info("Updating K8s ConfigMap")
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
 	cm.Data[caCrtField] = string(helpers.EncodeCertificatesPEM(c.CACerts))
 	_, err = k8sConfigMaps.Update(ctx, cm, meta_v1.UpdateOptions{})
 	if err != nil {


### PR DESCRIPTION
Follow-up to #507.

This fixes a small but real crash in the CA ConfigMap update path.
If the ConfigMap already exists but has no `data`, certgen blows up on `cm.Data["ca.crt"]`.
Kubernetes allows that object shape, so this is pretty easy to hit in GitOps or with a placeholder ConfigMap. Kinda silly crash tbh.

The fix just initializes the map before writing. Added a regression test too, thats it.

Repro
1. Create an empty ConfigMap:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-ca-cert
  namespace: kube-system
```
2. Run:
`cilium-certgen --k8s-kubeconfig-path=/path/to/kubeconfig --ca-generate=true --ca-secret-name=test-ca-secret --ca-secret-namespace=kube-system --ca-configmap-name=test-ca-cert --ca-configmap-namespace=kube-system`
3. On `main` this can panic with `assignment to entry in nil map`
4. With this patch it updates the ConfigMap fine

Tested with `go test ./...`

AIL:1 (minor AI assistance, polishing PR's description)
