### PR TITLE
docs: add pull-request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+Please ensure your pull request adheres to the following guidelines:
+
+- [ ] All commits contain a well written commit description including a title,
+      description and a `Fixes: #XXX` line if the commit addresses a particular
+      GitHub issue.
+- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
+      please add the commit author[s] as reviewer[s] to this issue.
+- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin]
+- [ ] Provide a title suitable for the release notes.
+- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
+      in accordance with the [Cilium AI Policy], and indicate the rating using
+      [AI Influence Level].
+      Example: "This PR was prepared with AIL:3. I personally checked X."
+- [ ] Thanks for contributing!
+
+<!-- Description of change -->
+
+Fixes: #issue-number
+
+[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
+[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
+[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo


### PR DESCRIPTION
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

We start to get some more external contributions to certgen, which is great!

I thought having some kind of pull-request template that links to some of our contributing guides, similar to the one in cilium, might help some of our first time contributors.

I essentially just copied the template from cilium, and removed some parts that didn't seem applicable.

[AIL:0]

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
