### PR TITLE
gha: add workflow to validate commits format

### DIFF
--- a/.github/workflows/lint-commits.yaml
+++ b/.github/workflows/lint-commits.yaml
@@ -1,0 +1,54 @@
+name: Lint commits
+on:
+  pull_request: {}
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint commits
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Validate authors and signed-off-by
+        run: |
+          set -euo pipefail
+
+          failed=0
+
+          while read -r revision; do
+            echo "Validating commit ${revision}"
+
+            # Check that 'noreply' emails are not used in authors.
+            if git show --no-patch "${revision}" \
+                | grep --invert-match 'renovate\[bot\]' \
+                | grep --ignore-case --quiet 'author.*noreply'; then
+
+              echo "Commit ${revision}: author uses a noreply email."
+              failed=1
+            fi
+
+            # Check that all commits have the Signed-off-by trailer
+            if ! git show --no-patch "${revision}" | grep --quiet --regexp 'Signed-off-by:'; then
+              echo "Commit ${revision}: missing Signed-off-by trailer."
+              failed=1
+            fi
+
+            # Check that 'noreply' emails are not used in Signed-off-by
+            if git show --no-patch "${revision}" \
+                | grep --invert-match --regexp 'renovate\[bot\]' \
+                | grep --quiet --regexp 'Signed-off-by:.*noreply'; then
+              echo "Commit ${revision}: Signed-off-by uses a noreply email."
+              failed=1
+            fi
+
+          done < <(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
+
+          exit ${failed}


### PR DESCRIPTION
Similarly to cilium/cilium, let's add a GitHub actions workflow to validate that every commit contains a Signed-off-by trailer, and it does not reference a noreply email. Similarly, let's validate that all authors don't use noreply emails.

[AIL:1]