### PR TITLE
version: prepare for v0.4.7 release

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -4,4 +4,4 @@
 package version
 
 // Version is the certgen version string.
-var Version = "0.4.5"
+var Version = "0.4.7"


### PR DESCRIPTION
Version `v0.4.6` was created by mistake without changing the version.go